### PR TITLE
TrackMate: DWIM swapped T/Z

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/ManualTrackingPlugIn_.java
+++ b/src/main/java/fiji/plugin/trackmate/ManualTrackingPlugIn_.java
@@ -18,6 +18,7 @@ public class ManualTrackingPlugIn_ extends TrackMatePlugIn_ implements PlugIn
 
 		final ImagePlus imp = WindowManager.getCurrentImage();
 		if ( null == imp ) { return; }
+		GuiUtils.userCheckImpDimensions( imp );
 
 		settings = createSettings( imp );
 		trackmate = createTrackMate();

--- a/src/main/java/fiji/plugin/trackmate/TrackMatePlugIn_.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMatePlugIn_.java
@@ -5,10 +5,7 @@ import fiji.plugin.trackmate.gui.TrackMateGUIController;
 import ij.ImageJ;
 import ij.ImagePlus;
 import ij.WindowManager;
-import ij.measure.Calibration;
 import ij.plugin.PlugIn;
-
-import javax.swing.JOptionPane;
 
 public class TrackMatePlugIn_ implements PlugIn
 {
@@ -22,24 +19,8 @@ public class TrackMatePlugIn_ implements PlugIn
 	{
 
 		final ImagePlus imp = WindowManager.getCurrentImage();
-
-		final int[] dims = imp.getDimensions();
-		if ( dims[ 4 ] == 1 && dims[ 3 ] > 1 )
-		{
-			switch ( JOptionPane.showConfirmDialog( null, "It appears this image has 1 timepoint but " + dims[ 3 ] + " slices.\n" + "Do you want to swap Z and T?", "Z/T swapped?", JOptionPane.YES_NO_CANCEL_OPTION ) )
-			{
-			case JOptionPane.YES_OPTION:
-				imp.setDimensions( dims[ 2 ], dims[ 4 ], dims[ 3 ] );
-				final Calibration calibration = imp.getCalibration();
-				if ( calibration.frameInterval == 0 )
-				{
-					calibration.frameInterval = 1;
-				}
-				break;
-			case JOptionPane.CANCEL_OPTION:
-				return;
-			}
-		}
+		if ( null == imp ) { return; }
+		GuiUtils.userCheckImpDimensions( imp );
 
 		settings = createSettings( imp );
 		trackmate = createTrackMate();

--- a/src/main/java/fiji/plugin/trackmate/gui/GuiUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/GuiUtils.java
@@ -1,5 +1,8 @@
 package fiji.plugin.trackmate.gui;
 
+import ij.ImagePlus;
+import ij.measure.Calibration;
+
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.DisplayMode;
@@ -8,6 +11,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 
 public class GuiUtils
 {
@@ -55,6 +59,27 @@ public class GuiUtils
 		else
 		{
 			gui.setLocationRelativeTo( null );
+		}
+	}
+
+	public static final void userCheckImpDimensions( final ImagePlus imp )
+	{
+		final int[] dims = imp.getDimensions();
+		if ( dims[ 4 ] == 1 && dims[ 3 ] > 1 )
+		{
+			switch ( JOptionPane.showConfirmDialog( null, "It appears this image has 1 timepoint but " + dims[ 3 ] + " slices.\n" + "Do you want to swap Z and T?", "Z/T swapped?", JOptionPane.YES_NO_CANCEL_OPTION ) )
+			{
+			case JOptionPane.YES_OPTION:
+				imp.setDimensions( dims[ 2 ], dims[ 4 ], dims[ 3 ] );
+				final Calibration calibration = imp.getCalibration();
+				if ( calibration.frameInterval == 0 )
+				{
+					calibration.frameInterval = 1;
+				}
+				break;
+			case JOptionPane.CANCEL_OPTION:
+				return;
+			}
 		}
 	}
 


### PR DESCRIPTION
When time and z are swapped, there is typically only one timepoint
(when there should be many). Detect the situation and ask the user
whether they wanted to swap the dimensions, but also offer them to
leave the dimensions as-are, or to cancel.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
