### PR TITLE
Added Jama's groupId (since it is no longer provided by pom-fiji)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 			<artifactId>fiji-compat</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>${jama.groupId}</groupId>
+			<groupId>gov.nist.math</groupId>
 			<artifactId>jama</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This explicit dependency could be removed since it is a dependency of pom-fiji. However, if it's kept the groupId has to be state explicitly..
