### PR TITLE
Fix scripts for the removed setFrom method

### DIFF
--- a/scripts/CallTrackMateMultiChannel.py
+++ b/scripts/CallTrackMateMultiChannel.py
@@ -39,8 +39,7 @@ if (dims[4] == 1):
 nChannels = imp.getNChannels()
 
 # Setup settings for TrackMate
-settings = Settings()
-settings.setFrom( imp )
+settings = Settings(imp)
 settings.dt = 0.05
 
 # Spot analyzer: we want the multi-C intensity analyzer.

--- a/scripts/ExampleScript_1.py
+++ b/scripts/ExampleScript_1.py
@@ -45,8 +45,7 @@ model.setLogger(Logger.IJ_LOGGER)
 # Prepare settings object
 #------------------------
 
-settings = Settings()
-settings.setFrom(imp)
+settings = Settings(imp)
 
 # Configure detector - We use the Strings for the keys
 settings.detectorFactory = LogDetectorFactory()

--- a/scripts/ExampleScript_3.py
+++ b/scripts/ExampleScript_3.py
@@ -39,8 +39,7 @@ model.setLogger(Logger.IJ_LOGGER)
 # Prepare settings object
 #------------------------
 
-settings = Settings()
-settings.setFrom( imp )
+settings = Settings(imp)
 
 # Configure detector
 settings.detectorFactory = DogDetectorFactory()

--- a/scripts/Run_TrackMate_Headless.groovy
+++ b/scripts/Run_TrackMate_Headless.groovy
@@ -26,8 +26,7 @@ if (dims[4] == 1) {
 }
 
 // Setup settings for TrackMate
-settings = new Settings()
-settings.setFrom(imp)
+settings = new Settings(imp)
 settings.dt = 0.05
 
 settings.detectorFactory = new LogDetectorFactory()


### PR DESCRIPTION
If I understand correctly, the ```setForm``` method has been suppressed from the ```Settings``` class in commit 033eb5c17e18463658e3e7ebd5348293ed08d0cc and now instead of:
```
settings = Settings()
settings.setFrom(imp)
```
one should use
```
settings = Settings(imp)
```
At least this fixed for me a bug when trying to run the [full example](https://imagej.net/plugins/trackmate/scripting#a-full-example) script from the Trackmate documentation. So I went ahead and fixed the 4 example scripts in this repo where ```setForm``` appeared and made this PR. It's the first time I use scripting in Trackmate, so please discard if this I'm completely mistaken and this is not relevant! If this is however accepted, I can also make a PR for the example scripts in the Fiji documentation itself.