### PR TITLE
Close gaps by detection and new framework for gap-closing methods.

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/action/autonaming/AutoNamingController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/autonaming/AutoNamingController.java
@@ -68,7 +68,7 @@ public class AutoNamingController
 			{
 				try
 				{
-					logger.log( "Applying nameing rule: " + autoNaming.toString() + ".\n" );
+					logger.log( "Applying naming rule: " + autoNaming.toString() + ".\n" );
 					logger.setStatus( "Spot auto-naming" );
 					AutoNamingPerformer.autoNameSpots( trackmate.getModel(), autoNaming );
 					trackmate.getModel().notifyFeaturesComputed();

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsAction.java
@@ -1,0 +1,81 @@
+package fiji.plugin.trackmate.action.closegaps;
+
+import java.awt.Frame;
+
+import javax.swing.ImageIcon;
+
+import org.scijava.plugin.Plugin;
+
+import fiji.plugin.trackmate.SelectionModel;
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.action.AbstractTMAction;
+import fiji.plugin.trackmate.action.TrackMateAction;
+import fiji.plugin.trackmate.action.TrackMateActionFactory;
+import fiji.plugin.trackmate.gui.Icons;
+import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings;
+
+public class CloseGapsAction extends AbstractTMAction
+{
+
+	public static final String NAME = "Close gaps by introducing new spots";
+
+	public static final String KEY = "CLOSE_GAPS";
+
+	public static final String INFO_TEXT = "<html>"
+			+ "This action proposes several methods to close gaps in tracks."
+			+ "<p>"
+			+ "Gaps are part of tracks where spots are missing in one or "
+			+ "several consecutive frames. The listed methods can "
+			+ "introduce new spots in such gaps, depending on possibly "
+			+ "the other spots in tracks and/or the image data."
+			+ "<p>"
+			+ "They are useful to fix missed detection when a uninterrupted "
+			+ "list of position is required for track analysis. For instance "
+			+ "in FRAP experiments, where you need to measure signal intensity "
+			+ "changing during time, even if the spot is not visible."
+			+ "</html>";
+
+	public static final ImageIcon ICON = Icons.ORANGE_ASTERISK_ICON;
+
+	@Override
+	public void execute( final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings, final Frame parent )
+	{
+		final CloseGapsController controller = new CloseGapsController( trackmate, logger );
+		controller.show();
+	}
+
+	@Plugin( type = TrackMateActionFactory.class )
+	public static class Factory implements TrackMateActionFactory
+	{
+
+		@Override
+		public String getInfoText()
+		{
+			return INFO_TEXT;
+		}
+
+		@Override
+		public String getKey()
+		{
+			return KEY;
+		}
+
+		@Override
+		public TrackMateAction create()
+		{
+			return new CloseGapsAction();
+		}
+
+		@Override
+		public ImageIcon getIcon()
+		{
+			return ICON;
+		}
+
+		@Override
+		public String getName()
+		{
+			return NAME;
+		}
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
@@ -21,6 +21,7 @@
  */
 package fiji.plugin.trackmate.action.closegaps;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.jgrapht.graph.DefaultWeightedEdge;
@@ -59,9 +60,20 @@ public class CloseGapsByDetection implements GapClosingMethod
 	public static final String NAME = "Close gaps by detection";
 
 	/**
-	 * Relative size of the seach radius, in spot radius units.
+	 * Relative size of the search radius, in spot radius units.
 	 */
-	private static final double SEARCH_RADIUS_FACTOR = 2.;
+	private final GapClosingParameter radiusFactor;
+
+	public CloseGapsByDetection()
+	{
+		this.radiusFactor = new GapClosingParameter( "Radius factor", 2., 0.1, 10. );
+	}
+
+	@Override
+	public List< GapClosingParameter > getParameters()
+	{
+		return Collections.singletonList( radiusFactor );
+	}
 
 	@Override
 	public void execute( final TrackMate trackmate, final Logger logger )
@@ -90,7 +102,10 @@ public class CloseGapsByDetection implements GapClosingMethod
 					final int t = spot.getFeature( Spot.FRAME ).intValue();
 
 					// Re-execute detection.
-					final Settings settings = GapClosingMethod.makeSettingsForRoiAround( spot, SEARCH_RADIUS_FACTOR, trackmate.getSettings() );
+					final Settings settings = GapClosingMethod.makeSettingsForRoiAround(
+							spot,
+							radiusFactor.value,
+							trackmate.getSettings() );
 					final TrackMate localTM = new TrackMate( settings );
 					localTM.getModel().setLogger( Logger.VOID_LOGGER );
 					localTM.setNumThreads( 1 );

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
@@ -1,0 +1,145 @@
+/*-
+ * #%L
+ * TrackMate: your buddy for everyday tracking.
+ * %%
+ * Copyright (C) 2010 - 2022 TrackMate developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package fiji.plugin.trackmate.action.closegaps;
+
+import java.util.List;
+
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Settings;
+import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.TrackModel;
+import net.imglib2.util.Util;
+
+/**
+ * This action allows to close gaps in tracks by executing detection in the
+ * vicinity of position that are linearly interpolated.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class CloseGapsByDetection implements GapClosingMethod
+{
+
+	public static final String INFO_TEXT = "<html>"
+			+ "This method allows to close gaps in tracks by executing a detection "
+			+ "in the vicinity of linearly interpolated position over a gap."
+			+ "<p>"
+			+ "The same detector and detection settings than for the initial detection step are used. "
+			+ "The search volume is built by taking a box of twice the interpolated radius of the "
+			+ "source and target spots at the gap."
+			+ "<p>"
+			+ "This method is best if there is a single spot near a missed detection that could "
+			+ "be recognized by the detection process executed in a smaller region. It is well "
+			+ "suited to be used with detectors that use a normalized threshold, like the Hessian "
+			+ "detector."
+			+ "</html>";
+
+	public static final String NAME = "Close gaps by detection";
+
+	/**
+	 * Relative size of the seach radius, in spot radius units.
+	 */
+	private static final double SEARCH_RADIUS_FACTOR = 2.;
+
+	@Override
+	public void execute( final TrackMate trackmate, final Logger logger )
+	{
+		final Model model = trackmate.getModel();
+		final TrackModel trackModel = model.getTrackModel();
+
+		// Copy settings & make a new TrackMate.
+
+		model.beginUpdate();
+		try
+		{
+			final List< DefaultWeightedEdge > gaps = GapClosingMethod.getAllGaps( model );
+			int progress = 0;
+			final int nTasks = GapClosingMethod.countMissingSpots( gaps, model );
+			for ( final DefaultWeightedEdge gap : gaps )
+			{
+				// Interpolate position.
+				final List< Spot > spots = GapClosingMethod.interpolate( model, gap );
+				final Spot source = trackModel.getEdgeSource( gap );
+				Spot current = source;
+				for ( final Spot spot : spots )
+				{
+					logger.setProgress( ( double ) ( progress++ ) / nTasks );
+
+					final int t = spot.getFeature( Spot.FRAME ).intValue();
+
+					// Re-execute detection.
+					final Settings settings = GapClosingMethod.makeSettingsForRoiAround( spot, SEARCH_RADIUS_FACTOR, trackmate.getSettings() );
+					final TrackMate localTM = new TrackMate( settings );
+					localTM.getModel().setLogger( Logger.VOID_LOGGER );
+					localTM.setNumThreads( 1 );
+					if ( !localTM.execDetection() )
+					{
+						logger.error( "Error detecting spots around position " + Util.printCoordinates( source )
+								+ " at frame " + t + ":\n"
+								+ localTM.getErrorMessage() );
+						continue;
+					}
+					// Did we find something?
+					Spot candidate = null;
+					for ( final Spot s : localTM.getModel().getSpots().iterable( t, false ) )
+					{
+						if ( candidate == null || s.diffTo( candidate, Spot.QUALITY ) > 0 )
+							candidate = s;
+					}
+					if ( candidate == null )
+					{
+						logger.log( "Could not find a suitable spot around position " + Util.printCoordinates( source )
+								+ " at frame " + t + ".\n" );
+						continue;
+					}
+					// Add new spot to the model.
+					model.addSpotTo( candidate, candidate.getFeature( Spot.FRAME ).intValue() );
+					model.addEdge( current, candidate, 1.0 );
+					current = candidate;
+				}
+				final Spot target = trackModel.getEdgeTarget( gap );
+				model.addEdge( current, target, 1.0 );
+				model.removeEdge( source, target );
+				logger.log( "Added " + spots.size() + " new spots between spots " + source + " and " + target + ".\n" );
+			}
+		}
+		finally
+		{
+			model.endUpdate();
+		}
+	}
+
+	@Override
+	public String getInfoText()
+	{
+		return INFO_TEXT;
+	}
+
+	@Override
+	public String toString()
+	{
+		return NAME;
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByDetection.java
@@ -108,7 +108,7 @@ public class CloseGapsByDetection implements GapClosingMethod
 							trackmate.getSettings() );
 					final TrackMate localTM = new TrackMate( settings );
 					localTM.getModel().setLogger( Logger.VOID_LOGGER );
-					localTM.setNumThreads( 1 );
+					localTM.setNumThreads( trackmate.getNumThreads() );
 					if ( !localTM.execDetection() )
 					{
 						logger.error( "Error detecting spots around position " + Util.printCoordinates( source )

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByLinearInterpolation.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByLinearInterpolation.java
@@ -44,7 +44,7 @@ import fiji.plugin.trackmate.TrackModel;
  * Date: June 2016
  *
  */
-public class CloseGapsByLinearInterpolationAction implements GapClosingMethod
+public class CloseGapsByLinearInterpolation implements GapClosingMethod
 {
 
 	public static final String INFO_TEXT = "<html>This action allows to close gaps in tracks by intercalating "

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByLinearInterpolationAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsByLinearInterpolationAction.java
@@ -19,31 +19,24 @@
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
  * #L%
  */
-package fiji.plugin.trackmate.action;
+package fiji.plugin.trackmate.action.closegaps;
 
-import static fiji.plugin.trackmate.gui.Icons.ORANGE_ASTERISK_ICON;
-
-import java.awt.Frame;
 import java.util.Set;
 
-import javax.swing.ImageIcon;
-
 import org.jgrapht.graph.DefaultWeightedEdge;
-import org.scijava.plugin.Plugin;
 
+import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Model;
-import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.TrackModel;
-import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings;
 import net.imglib2.RealPoint;
 
 /**
  * This action allows to close gaps in tracks by creating new intermediate spots
  * which are located at interpolated positions. This is useful if you want to
  * measure signal intensity changing during time, even if the spot is not
- * visible. Thus, trackmate is utilisable for Fluorescence Recovery after
+ * visible. Thus, TrackMate is usable for Fluorescence Recovery after
  * Photobleaching (FRAP) analysis.
  *
  * Author: Robert Haase, Scientific Computing Facility, MPI-CBG,
@@ -52,27 +45,22 @@ import net.imglib2.RealPoint;
  * Date: June 2016
  *
  */
-public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
+public class CloseGapsByLinearInterpolationAction implements GapClosingMethod
 {
 
-	public static final String NAME = "Close gaps by introducing new spots";
+	public static final String INFO_TEXT = "<html>This action allows to close gaps in tracks by intercalating "
+			+ "new spots in gaps which position is interpolated from the positions of the true spots "
+			+ "at the gap beginning and end. The image data is not used to adjust the position of spots.</html>";
 
-	public static final String KEY = "CLOSE_GAPS_BY_LINEAR_INPERPOLATION";
-
-	public static final String INFO_TEXT = "<html>"
-			+ "This action closes gaps in tracks by introducing new spots. "
-			+ "The spots positions and size are calculated "
-			+ "using linear interpolation."
-			+ "</html>";
+	public static final String NAME = "Close gaps by interpolating positions";
 
 	@Override
-	public void execute( final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings, final Frame parent )
+	public void execute( final TrackMate trackmate, final Logger logger )
 	{
 		final Model model = trackmate.getModel();
 		final TrackModel trackModel = model.getTrackModel();
 		boolean changed = true;
 
-		logger.log( "Interpolating gaps.\n" );
 		model.beginUpdate();
 		try
 		{
@@ -150,52 +138,26 @@ public class CloseGapsByLinearInterpolationAction extends AbstractTMAction
 		{
 			model.endUpdate();
 		}
-		logger.log( "Finished.\n" );
 	}
 
 	private void interpolateFeature( final Spot targetSpot, final Spot spot1, final Spot spot2, final double weight, final String feature )
 	{
 		if ( targetSpot.getFeatures().containsKey( feature ) )
-		{
 			targetSpot.getFeatures().remove( feature );
-		}
 
 		targetSpot.getFeatures().put( feature,
 				weight * spot1.getFeature( feature ) + ( 1.0 - weight ) * spot2.getFeature( feature ) );
 	}
 
-	@Plugin( type = TrackMateActionFactory.class )
-	public static class Factory implements TrackMateActionFactory
+	@Override
+	public String getInfoText()
 	{
+		return INFO_TEXT;
+	}
 
-		@Override
-		public String getInfoText()
-		{
-			return INFO_TEXT;
-		}
-
-		@Override
-		public String getName()
-		{
-			return NAME;
-		}
-
-		@Override
-		public String getKey()
-		{
-			return KEY;
-		}
-
-		@Override
-		public ImageIcon getIcon()
-		{
-			return ORANGE_ASTERISK_ICON;
-		}
-
-		@Override
-		public TrackMateAction create()
-		{
-			return new CloseGapsByLinearInterpolationAction();
-		}
+	@Override
+	public String toString()
+	{
+		return NAME;
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
@@ -64,7 +64,7 @@ public class CloseGapsController
 
 		final JFrame frame = new JFrame( "TrackMate gap-closing" );
 		frame.setIconImage( CloseGapsAction.ICON.getImage() );
-		frame.setSize( 500, 400 );
+		frame.setSize( 300, 500 );
 		frame.getContentPane().add( gui );
 		GuiUtils.positionWindow( frame, trackmate.getSettings().imp.getCanvas() );
 		frame.setVisible( true );

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
@@ -25,8 +25,9 @@ public class CloseGapsController
 		this.trackmate = trackmate;
 		this.logger = logger;
 
-		final Collection< GapClosingMethod > gapClosingMethods = new ArrayList<>( 1 );
+		final Collection< GapClosingMethod > gapClosingMethods = new ArrayList<>( 2 );
 		gapClosingMethods.add( new CloseGapsByLinearInterpolation() );
+		gapClosingMethods.add( new CloseGapsByDetection() );
 
 		this.gui = new CloseGapsPanel( gapClosingMethods );
 		gui.btnRun.addActionListener( e -> run( ( ( GapClosingMethod ) gui.cmbboxMethod.getSelectedItem() ) ) );

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
@@ -1,0 +1,71 @@
+package fiji.plugin.trackmate.action.closegaps;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+
+import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.gui.GuiUtils;
+import fiji.plugin.trackmate.util.EverythingDisablerAndReenabler;
+
+public class CloseGapsController
+{
+
+	private final TrackMate trackmate;
+
+	private final Logger logger;
+
+	private final CloseGapsPanel gui;
+
+	public CloseGapsController( final TrackMate trackmate, final Logger logger )
+	{
+		this.trackmate = trackmate;
+		this.logger = logger;
+
+		final Collection< GapClosingMethod > gapClosingMethods = new ArrayList<>( 1 );
+		gapClosingMethods.add( new CloseGapsByLinearInterpolationAction() );
+
+		this.gui = new CloseGapsPanel( gapClosingMethods );
+		gui.btnRun.addActionListener( e -> run( ( ( GapClosingMethod ) gui.cmbboxMethod.getSelectedItem() ) ) );
+	}
+
+	private void run( final GapClosingMethod gapClosingMethod )
+	{
+		final EverythingDisablerAndReenabler disabler = new EverythingDisablerAndReenabler( gui, new Class[] { JLabel.class } );
+		disabler.disable();
+		new Thread( "TrackMateGapClosingThread" )
+		{
+			@Override
+			public void run()
+			{
+				try
+				{
+					logger.log( "Applying gap-closing method: " + gapClosingMethod.toString() + ".\n" );
+					logger.setStatus( "Gap-closing" );
+					gapClosingMethod.execute( trackmate, logger );
+					logger.log( "Gap-closing done.\n" );
+				}
+				finally
+				{
+					disabler.reenable();
+				}
+			}
+		}.start();
+	}
+
+	public void show()
+	{
+		if ( gui.getParent() != null && gui.getParent().isVisible() )
+			return;
+
+		final JFrame frame = new JFrame( "TrackMate gap-closing" );
+		frame.setIconImage( CloseGapsAction.ICON.getImage() );
+		frame.setSize( 500, 400 );
+		frame.getContentPane().add( gui );
+		GuiUtils.positionWindow( frame, trackmate.getSettings().imp.getCanvas() );
+		frame.setVisible( true );
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
@@ -26,7 +26,7 @@ public class CloseGapsController
 		this.logger = logger;
 
 		final Collection< GapClosingMethod > gapClosingMethods = new ArrayList<>( 1 );
-		gapClosingMethods.add( new CloseGapsByLinearInterpolationAction() );
+		gapClosingMethods.add( new CloseGapsByLinearInterpolation() );
 
 		this.gui = new CloseGapsPanel( gapClosingMethods );
 		gui.btnRun.addActionListener( e -> run( ( ( GapClosingMethod ) gui.cmbboxMethod.getSelectedItem() ) ) );

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsPanel.java
@@ -1,0 +1,107 @@
+package fiji.plugin.trackmate.action.closegaps;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.Collection;
+import java.util.Vector;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+
+import fiji.plugin.trackmate.gui.Fonts;
+
+/**
+ * A basic UI to let a TrackMate user choose between several techniques for gap
+ * closing.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class CloseGapsPanel extends JPanel
+{
+
+	private static final long serialVersionUID = 1L;
+
+	final JComboBox< GapClosingMethod > cmbboxMethod;
+
+	final JButton btnRun;
+
+	public CloseGapsPanel( final Collection< GapClosingMethod > gapClosingMethods )
+	{
+		setBorder( new EmptyBorder( 5, 5, 5, 5 ) );
+		final GridBagLayout gridBagLayout = new GridBagLayout();
+		gridBagLayout.columnWidths = new int[] { 0, 0, 0 };
+		gridBagLayout.rowHeights = new int[] { 0, 0, 0, 0, 0, 0 };
+		gridBagLayout.columnWeights = new double[] { 1.0, 1.0, Double.MIN_VALUE };
+		gridBagLayout.rowWeights = new double[] { 0.0, 0.0, 0.0, 1.0, 0.0, Double.MIN_VALUE };
+		setLayout( gridBagLayout );
+
+		final JLabel lblTitle = new JLabel( "Close gap" );
+		lblTitle.setFont( Fonts.BIG_FONT );
+		lblTitle.setHorizontalAlignment( SwingConstants.CENTER );
+		final GridBagConstraints gbcLblTitle = new GridBagConstraints();
+		gbcLblTitle.gridwidth = 2;
+		gbcLblTitle.insets = new Insets( 0, 0, 5, 0 );
+		gbcLblTitle.fill = GridBagConstraints.BOTH;
+		gbcLblTitle.gridx = 0;
+		gbcLblTitle.gridy = 0;
+		add( lblTitle, gbcLblTitle );
+
+		final JLabel lblDoc = new JLabel( CloseGapsAction.INFO_TEXT );
+		lblDoc.setFont( Fonts.SMALL_FONT );
+		final GridBagConstraints gbcLblDoc = new GridBagConstraints();
+		gbcLblDoc.fill = GridBagConstraints.BOTH;
+		gbcLblDoc.insets = new Insets( 0, 0, 5, 0 );
+		gbcLblDoc.gridwidth = 2;
+		gbcLblDoc.gridx = 0;
+		gbcLblDoc.gridy = 1;
+		add( lblDoc, gbcLblDoc );
+
+		final JLabel lblMethod = new JLabel( "Gap-closing method" );
+		lblMethod.setFont( Fonts.SMALL_FONT );
+		final GridBagConstraints gbcLblMethod = new GridBagConstraints();
+		gbcLblMethod.anchor = GridBagConstraints.EAST;
+		gbcLblMethod.insets = new Insets( 0, 0, 5, 5 );
+		gbcLblMethod.gridx = 0;
+		gbcLblMethod.gridy = 2;
+		add( lblMethod, gbcLblMethod );
+
+		this.cmbboxMethod = new JComboBox<>( new Vector<>( gapClosingMethods ) );
+		cmbboxMethod.setFont( Fonts.SMALL_FONT );
+		final GridBagConstraints gbcCmbboxMethod = new GridBagConstraints();
+		gbcCmbboxMethod.insets = new Insets( 0, 0, 5, 0 );
+		gbcCmbboxMethod.fill = GridBagConstraints.HORIZONTAL;
+		gbcCmbboxMethod.gridx = 1;
+		gbcCmbboxMethod.gridy = 2;
+		add( cmbboxMethod, gbcCmbboxMethod );
+
+		final JLabel lblMethodDoc = new JLabel();
+		lblMethodDoc.setFont( Fonts.SMALL_FONT );
+		final GridBagConstraints gbcLblMethodDoc = new GridBagConstraints();
+		gbcLblMethodDoc.fill = GridBagConstraints.BOTH;
+		gbcLblMethodDoc.insets = new Insets( 0, 0, 5, 0 );
+		gbcLblMethodDoc.gridwidth = 2;
+		gbcLblMethodDoc.gridx = 0;
+		gbcLblMethodDoc.gridy = 3;
+		add( lblMethodDoc, gbcLblMethodDoc );
+
+		this.btnRun = new JButton( "Run" );
+		final GridBagConstraints gbcBtnRun = new GridBagConstraints();
+		gbcBtnRun.anchor = GridBagConstraints.EAST;
+		gbcBtnRun.gridx = 1;
+		gbcBtnRun.gridy = 4;
+		add( btnRun, gbcBtnRun );
+
+		/*
+		 * Listeners.
+		 */
+
+		cmbboxMethod.addActionListener( e -> lblMethodDoc.setText( ( ( GapClosingMethod ) cmbboxMethod.getSelectedItem() ).getInfoText() ) );
+		cmbboxMethod.setSelectedIndex( 0 );
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
@@ -234,6 +234,11 @@ public interface GapClosingMethod
 		// Make a new settings with a smaller ROI.
 		final Settings settingsCopy = settings.copyOn( settings.imp );
 		settingsCopy.setRoi( new Roi( x0, y0, x1 - x0, y1 - y0 ) );
+		// Time.
+		final int t = spot.getFeature( Spot.FRAME ).intValue();
+		settingsCopy.tstart = t;
+		settingsCopy.tend = t;
+
 		if ( !DetectionUtils.is2D( settings.imp ) )
 		{
 			// 3D

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
@@ -22,6 +22,7 @@
 package fiji.plugin.trackmate.action.closegaps;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -40,6 +41,38 @@ import net.imglib2.RealPoint;
 
 public interface GapClosingMethod
 {
+
+	public static class GapClosingParameter
+	{
+
+		public final String name;
+
+		public double value;
+
+		public final double minValue;
+
+		public final double maxValue;
+
+		public GapClosingParameter( final String name, final double value, final double minValue, final double maxValue )
+		{
+			this.name = name;
+			this.value = value;
+			this.minValue = minValue;
+			this.maxValue = maxValue;
+		}
+	}
+
+	/**
+	 * Returns the list of parameters required to configure this method.
+	 * <p>
+	 * The list will be used to autogenerate a configuration panel.
+	 * 
+	 * @return a list of parameters.
+	 */
+	public default List< GapClosingParameter > getParameters()
+	{
+		return Collections.emptyList();
+	}
 
 	/**
 	 * Returns a html string containing a descriptive information about this

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * TrackMate: your buddy for everyday tracking.
+ * %%
+ * Copyright (C) 2010 - 2022 TrackMate developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+package fiji.plugin.trackmate.action.closegaps;
+
+import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.TrackMate;
+
+public interface GapClosingMethod
+{
+
+	/**
+	 * Returns a html string containing a descriptive information about this
+	 * module.
+	 *
+	 * @return a html string.
+	 */
+	public String getInfoText();
+
+	/**
+	 * Performs the gap closing.
+	 * 
+	 * @param trackmate
+	 * @param logger
+	 */
+	public void execute( TrackMate trackmate, Logger logger );
+
+}

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/GapClosingMethod.java
@@ -21,8 +21,18 @@
  */
 package fiji.plugin.trackmate.action.closegaps;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.jgrapht.graph.DefaultWeightedEdge;
+
 import fiji.plugin.trackmate.Logger;
+import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
+import fiji.plugin.trackmate.TrackModel;
+import net.imglib2.RealPoint;
 
 public interface GapClosingMethod
 {
@@ -43,4 +53,101 @@ public interface GapClosingMethod
 	 */
 	public void execute( TrackMate trackmate, Logger logger );
 
+	/**
+	 * Utility method that can return all the edges of a model that have a gap.
+	 * <p>
+	 * A gap corresponds to spots that are missing in one or several consecutive
+	 * frames within a track. Gaps are returned as a list of edges. Each edge in
+	 * this list has a source spot and a target spot separated by strictly more
+	 * than 1 frame.
+	 * 
+	 * @param model
+	 *            the model to search for gaps.
+	 * @return a list of edges corresponding to gaps.
+	 */
+	public static List< DefaultWeightedEdge > getAllGaps( final Model model )
+	{
+		final List< DefaultWeightedEdge > gaps = new ArrayList<>();
+		final TrackModel trackModel = model.getTrackModel();
+		final Set< DefaultWeightedEdge > edges = trackModel.edgeSet();
+		for ( final DefaultWeightedEdge edge : edges )
+		{
+			final Spot source = trackModel.getEdgeSource( edge );
+			final int st = source.getFeature( Spot.FRAME ).intValue();
+			final Spot target = trackModel.getEdgeTarget( edge );
+			final int tt = target.getFeature( Spot.FRAME ).intValue();
+
+			if ( Math.abs( tt - st ) > 1 )
+				gaps.add( edge );
+		}
+		return gaps;
+	}
+
+	/**
+	 * Returns a list of newly created spots obtained by interpolating the
+	 * position, radius, quality and time features of the source and target spot
+	 * of the specified edge.
+	 * <p>
+	 * The list is not empty only the edge bridges a gap, or if the source and
+	 * target spots are separated by strictly more than 1 frame.
+	 * <p>
+	 * In the list, the spots are <b>not</b> added to the model and are <b>not
+	 * linked</b> be edges. The spots are added in time order, from the frame
+	 * just after the source spot, to the frame just before the target spot. The
+	 * source and target spot are not in the list.
+	 * 
+	 * @param model
+	 *            the model.
+	 * @param edge
+	 *            the edge to interpolate.
+	 * @return a new list of spots.
+	 */
+	public static List< Spot > interpolate( final Model model, final DefaultWeightedEdge edge )
+	{
+		final TrackModel trackModel = model.getTrackModel();
+
+		final Spot source = trackModel.getEdgeSource( edge );
+		final double[] sPos = new double[ 3 ];
+		source.localize( sPos );
+		final int st = source.getFeature( Spot.FRAME ).intValue();
+
+		final Spot target = trackModel.getEdgeTarget( edge );
+		final double[] tPos = new double[ 3 ];
+		target.localize( tPos );
+		final int tt = target.getFeature( Spot.FRAME ).intValue();
+		
+		final List< Spot > interpolatedSpots = new ArrayList<>( Math.abs( tt - st ) - 1 );
+
+		final int presign = tt > st ? 1 : -1;
+		for ( int f = st + presign; ( f < tt && presign == 1 )
+				|| ( f > tt && presign == -1 ); f += presign )
+		{
+			final double weight = ( double ) ( tt - f ) / ( tt - st );
+
+			final double[] position = new double[ 3 ];
+			for ( int d = 0; d < 3; d++ )
+				position[ d ] = weight * sPos[ d ] + ( 1.0 - weight ) * tPos[ d ];
+
+			final RealPoint rp = new RealPoint( position );
+			final Spot newSpot = new Spot( rp, 0, 0 );
+			newSpot.putFeature( Spot.FRAME, Double.valueOf( f ) );
+
+			// Set some properties of the new spot
+			interpolateFeature( newSpot, source, target, weight, Spot.RADIUS );
+			interpolateFeature( newSpot, source, target, weight, Spot.QUALITY );
+			interpolateFeature( newSpot, source, target, weight, Spot.POSITION_T );
+
+			interpolatedSpots.add( newSpot );
+		}
+		return interpolatedSpots;
+	}
+
+	static void interpolateFeature( final Spot targetSpot, final Spot spot1, final Spot spot2, final double weight, final String feature )
+	{
+		if ( targetSpot.getFeatures().containsKey( feature ) )
+			targetSpot.getFeatures().remove( feature );
+
+		targetSpot.getFeatures().put( feature,
+				weight * spot1.getFeature( feature ) + ( 1.0 - weight ) * spot2.getFeature( feature ) );
+	}
 }

--- a/src/main/java/fiji/plugin/trackmate/gui/components/ActionChooserPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/ActionChooserPanel.java
@@ -25,6 +25,7 @@ import static fiji.plugin.trackmate.gui.Fonts.FONT;
 import static fiji.plugin.trackmate.gui.Icons.EXECUTE_ICON;
 
 import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -50,6 +51,9 @@ public class ActionChooserPanel extends ModuleChooserPanel< TrackMateActionFacto
 	public ActionChooserPanel( final ActionProvider actionProvider, final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings )
 	{
 		super( actionProvider, "action", CaptureOverlayAction.KEY );
+		
+		final GridBagLayout gridBagLayout = ( GridBagLayout ) getLayout();
+		gridBagLayout.rowHeights = new int[] { 16, 27, 209, 200 };
 
 		final LogPanel logPanel = new LogPanel();
 		final GridBagConstraints gbcLogPanel = new GridBagConstraints();

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -27,6 +27,7 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.traverse.GraphIterator;
 import org.junit.Test;
 
+import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
@@ -68,7 +69,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gap
 		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
-		cgblia.execute( trackmate, null );
+		cgblia.execute( trackmate, Logger.VOID_LOGGER );
 
 		final TrackModel trackModel = model.getTrackModel();
 
@@ -110,7 +111,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gaps
 		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
-		cgblia.execute( trackmate, null );
+		cgblia.execute( trackmate, Logger.VOID_LOGGER );
 
 		final TrackModel trackModel = model.getTrackModel();
 
@@ -152,7 +153,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gaps
 		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
-		cgblia.execute( trackmate, null );
+		cgblia.execute( trackmate, Logger.VOID_LOGGER );
 
 		final TrackModel trackModel = model.getTrackModel();
 

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -31,7 +31,7 @@ import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.TrackModel;
-import fiji.plugin.trackmate.action.closegaps.CloseGapsByLinearInterpolationAction;
+import fiji.plugin.trackmate.action.closegaps.CloseGapsByLinearInterpolation;
 
 /**
  * Author: Robert Haase, Scientific Computing Facility, MPI-CBG,
@@ -67,7 +67,7 @@ public class CloseGapsByLinearInterpolationActionTest
 		model.endUpdate();
 
 		// close gap
-		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
 		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();
@@ -109,7 +109,7 @@ public class CloseGapsByLinearInterpolationActionTest
 		model.endUpdate();
 
 		// close gaps
-		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
 		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();
@@ -151,7 +151,7 @@ public class CloseGapsByLinearInterpolationActionTest
 		model.endUpdate();
 
 		// close gaps
-		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
+		final CloseGapsByLinearInterpolation cgblia = new CloseGapsByLinearInterpolation();
 		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();

--- a/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
+++ b/src/test/java/fiji/plugin/trackmate/action/CloseGapsByLinearInterpolationActionTest.java
@@ -31,6 +31,7 @@ import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.TrackModel;
+import fiji.plugin.trackmate.action.closegaps.CloseGapsByLinearInterpolationAction;
 
 /**
  * Author: Robert Haase, Scientific Computing Facility, MPI-CBG,
@@ -67,7 +68,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gap
 		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
-		cgblia.execute( trackmate, null, null, null );
+		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();
 
@@ -109,7 +110,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gaps
 		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
-		cgblia.execute( trackmate, null, null, null );
+		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();
 
@@ -151,7 +152,7 @@ public class CloseGapsByLinearInterpolationActionTest
 
 		// close gaps
 		final CloseGapsByLinearInterpolationAction cgblia = new CloseGapsByLinearInterpolationAction();
-		cgblia.execute( trackmate, null, null, null );
+		cgblia.execute( trackmate, null );
 
 		final TrackModel trackModel = model.getTrackModel();
 


### PR DESCRIPTION
This PR offers a new gap-closing method and the means to add other gap-closing methods in the future.

Gaps are part of tracks where spots are missing in one or several consecutive frames. The gap-closing methods we are offering can introduce new spots in such gaps, depending on possibly the other spots in tracks and/or the image data.
They are useful to fix missed detection when a uninterrupted list of position is required for track analysis. For instance in FRAP experiments, where you need to measure signal intensity changing during time, even if the spot is not visible.

So far TrackMate offered one method to close gaps, developed by @haesleinhuepf. It consists in interpolating the position and radius of missing spots. 

In this PR we introduce a new method that execute a detection process around each interpolated positions. The detection is constrained to happen in the vicinity of the interpolated position, in a ROI of size a multiple of the spot radius. 

The UI to choose and configure a gap-closing method looks like this:
![Screenshot 2023-01-17 at 18 40 46](https://user-images.githubusercontent.com/3583203/212974003-261b0bb9-a291-4d4a-ab23-4cb7bc243810.png)

Here the user chose the new gap-closing method. It can be configured with one parameter: the search radius factor, in units of the initial spot radius. 
The detection process reuse the exact same parameters that were used in the last detection step in TrackMate. They simply run on a smaller ROI.

For instance, if we create a gigantic gap between two spots well apart in time, we have a track that looks like this:

![Screenshot 2023-01-17 at 18 40 27](https://user-images.githubusercontent.com/3583203/212974367-1125183d-3126-46f4-861c-a20fab1c1668.png)
(the first spot in time is in the top-middle location of the image, the last one in the bottom middle).

After running the gap-closing method with a search radius of about 5, we get this:
![Screenshot 2023-01-17 at 18 40 49](https://user-images.githubusercontent.com/3583203/212974532-67c1c924-28af-4f03-99de-8c2c25f0cd56.png)
The new spots intercalated are positioned where bright objects are. 

The algorithm takes the spot with the highest quality if there are several found. 


