### PR TITLE
Addition of average time between a branch and its successors in Branch Analysis action

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
@@ -243,13 +243,20 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 			{
 				final Set< List< Spot > > succs = successorMap.get( br );
 				final Set< Branch > succBrs = new HashSet<>( succs.size() );
-				for ( final List< Spot > branch : succs )
+				double meanDeltaTSucc = 0;
+                                for ( final List< Spot > branch : succs )
 				{
 					final Branch succBr = branchMap.get( branch );
+                                        // temporal distance with successor (if there are gaps)
+                                        meanDeltaTSucc += succBr.first.diffTo(br.last, Spot.POSITION_T);
 					succBrs.add( succBr );
 				}
 				br.successors = succBrs;
 				br.putFeature( N_SUCCESSORS, Double.valueOf( succBrs.size() ) );
+                                 if ( br.getFeature(N_SUCCESSORS) > 0 )
+                                    br.putFeature( MEAN_SUCCESSORS_DELAY, meanDeltaTSucc/br.getFeature(N_SUCCESSORS) );
+                                else
+                                    br.putFeature( MEAN_SUCCESSORS_DELAY, 0.0 );
 
 				final Set< List< Spot > > preds = predecessorMap.get( br );
 				final Set< Branch > predBrs = new HashSet<>( preds.size() );
@@ -463,6 +470,8 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 	private static final String MEAN_VELOCITY = "MEAN_VELOCITY";
 	private static final String FIRST = "FIRST";
 	private static final String LAST = "LAST";
+        // mean temporal distance between end of the branch and begin of successors branch
+        private static final String MEAN_SUCCESSORS_DELAY = "MEAN_SUCCESSORS_DELAY";
 	private static final List< String > BRANCH_FEATURES = Arrays.asList( new String[] {
 			TRACK_ID,
 			N_PREDECESSORS,
@@ -471,7 +480,8 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 			DISTANCE,
 			MEAN_VELOCITY,
 			FIRST,
-			LAST
+			LAST,
+                        MEAN_SUCCESSORS_DELAY
 	} );
 
 	private static final Map< String, String > BRANCH_FEATURES_NAMES = new HashMap<>();
@@ -519,5 +529,12 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 		BRANCH_FEATURES_SHORTNAMES.put( LAST, "Last ID" );
 		BRANCH_FEATURES_ISINTS.put( LAST, Boolean.TRUE );
 		BRANCH_FEATURES_DIMENSIONS.put( LAST, Dimension.NONE );
+                
+                 // Mean duration between end of the branch and begin of successors branch
+                BRANCH_FEATURES_NAMES.put( MEAN_SUCCESSORS_DELAY, "Mean successors delay" );
+		BRANCH_FEATURES_SHORTNAMES.put( MEAN_SUCCESSORS_DELAY, "Succ Delay" );
+		BRANCH_FEATURES_ISINTS.put( MEAN_SUCCESSORS_DELAY, Boolean.FALSE );
+		BRANCH_FEATURES_DIMENSIONS.put( MEAN_SUCCESSORS_DELAY, Dimension.TIME );
+               
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
@@ -260,13 +260,20 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 
 				final Set< List< Spot > > preds = predecessorMap.get( br );
 				final Set< Branch > predBrs = new HashSet<>( preds.size() );
+                                double meanDeltaTPred = 0;
 				for ( final List< Spot > branch : preds )
 				{
 					final Branch predBr = branchMap.get( branch );
+                                        // temporal distance with predecessor (if there are gaps)
+                                        meanDeltaTPred += br.first.diffTo(predBr.last, Spot.POSITION_T);
 					predBrs.add( predBr );
 				}
 				br.predecessors = predBrs;
 				br.putFeature( N_PREDECESSORS, Double.valueOf( predBrs.size() ) );
+                                if ( br.getFeature(N_PREDECESSORS) > 0 )
+                                    br.putFeature( MEAN_PREDECESSORS_DELAY, meanDeltaTPred/br.getFeature(N_PREDECESSORS) );
+                                else
+                                    br.putFeature( MEAN_PREDECESSORS_DELAY, 0.0 );
 			}
 
 			brs.addAll( successorMap.keySet() );
@@ -472,6 +479,8 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 	private static final String LAST = "LAST";
         // mean temporal distance between end of the branch and begin of successors branch
         private static final String MEAN_SUCCESSORS_DELAY = "MEAN_SUCCESSORS_DELAY";
+        // mean temporal distance between begin of branch and end of predecessors branch
+        private static final String MEAN_PREDECESSORS_DELAY = "MEAN_PREDECESSORS_DELAY";
 	private static final List< String > BRANCH_FEATURES = Arrays.asList( new String[] {
 			TRACK_ID,
 			N_PREDECESSORS,
@@ -481,7 +490,8 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 			MEAN_VELOCITY,
 			FIRST,
 			LAST,
-                        MEAN_SUCCESSORS_DELAY
+                        MEAN_SUCCESSORS_DELAY,
+                        MEAN_PREDECESSORS_DELAY
 	} );
 
 	private static final Map< String, String > BRANCH_FEATURES_NAMES = new HashMap<>();
@@ -536,5 +546,10 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 		BRANCH_FEATURES_ISINTS.put( MEAN_SUCCESSORS_DELAY, Boolean.FALSE );
 		BRANCH_FEATURES_DIMENSIONS.put( MEAN_SUCCESSORS_DELAY, Dimension.TIME );
                
+                 // Mean duration between begin of the branch and end of predecessors branch
+                BRANCH_FEATURES_NAMES.put( MEAN_PREDECESSORS_DELAY, "Mean predecessors delay" );
+		BRANCH_FEATURES_SHORTNAMES.put( MEAN_PREDECESSORS_DELAY, "Pred Delay" );
+		BRANCH_FEATURES_ISINTS.put( MEAN_PREDECESSORS_DELAY, Boolean.FALSE );
+		BRANCH_FEATURES_DIMENSIONS.put( MEAN_PREDECESSORS_DELAY, Dimension.TIME );
 	}
 }


### PR DESCRIPTION
Addition of 2 colomns to the Branch Analysis table to give the average time between the analysed branch and the successors (or predecessors) branchs, in case there are gaps in the tracks.