### PR TITLE
Register TrackMate with ObjectService

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/TrackMatePlugIn.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMatePlugIn.java
@@ -25,12 +25,15 @@ import static fiji.plugin.trackmate.gui.Icons.TRACKMATE_ICON;
 
 import javax.swing.JFrame;
 
+import org.scijava.object.ObjectService;
+
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings;
 import fiji.plugin.trackmate.gui.displaysettings.DisplaySettingsIO;
 import fiji.plugin.trackmate.gui.wizard.TrackMateWizardSequence;
 import fiji.plugin.trackmate.gui.wizard.WizardSequence;
 import fiji.plugin.trackmate.io.SettingsPersistence;
+import fiji.plugin.trackmate.util.TMUtils;
 import fiji.plugin.trackmate.visualization.TrackMateModelView;
 import fiji.plugin.trackmate.visualization.hyperstack.HyperStackDisplayer;
 import ij.IJ;
@@ -169,6 +172,9 @@ public class TrackMatePlugIn implements PlugIn
 		model.setPhysicalUnits( spaceUnits, timeUnits );
 
 		final TrackMate trackmate = new TrackMate( model, settings );
+		ObjectService objectService = TMUtils.getContext().service( ObjectService.class );
+		if ( objectService != null )
+			objectService.addObject( trackmate );
 
 		// Set the num of threads from IJ prefs.
 		trackmate.setNumThreads( Prefs.getThreads() );

--- a/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
@@ -712,10 +712,16 @@ public class TMUtils
 	/** Obtains the SciJava {@link Context} in use by ImageJ. */
 	public static Context getContext()
 	{
-		if (context == null) {
-			context = (Context) IJ.runPlugIn( "org.scijava.Context", "" );
+		final Context localContext = context;
+		if (localContext != null)
+			return localContext;
+		
+		synchronized (TMUtils.class)
+		{
+			if (context == null)
+				context = ( Context ) IJ.runPlugIn( "org.scijava.Context", "" );
+			return context;
 		}
-		return context;
 	}
 
 	/**

--- a/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/util/TMUtils.java
@@ -66,6 +66,7 @@ public class TMUtils
 {
 
 	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat( "EEE, d MMM yyyy HH:mm:ss" );
+	private static Context context;
 
 	/*
 	 * STATIC METHODS
@@ -711,7 +712,10 @@ public class TMUtils
 	/** Obtains the SciJava {@link Context} in use by ImageJ. */
 	public static Context getContext()
 	{
-		return ( Context ) IJ.runPlugIn( "org.scijava.Context", "" );
+		if (context == null) {
+			context = (Context) IJ.runPlugIn( "org.scijava.Context", "" );
+		}
+		return context;
 	}
 
 	/**

--- a/src/test/java/fiji/plugin/trackmate/TrackMatePluginTest.java
+++ b/src/test/java/fiji/plugin/trackmate/TrackMatePluginTest.java
@@ -1,0 +1,43 @@
+package fiji.plugin.trackmate;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.object.ObjectService;
+
+import fiji.plugin.trackmate.util.TMUtils;
+import ij.IJ;
+import ij.ImagePlus;
+
+public class TrackMatePluginTest {
+
+	@Test
+	public void testTrackMateRegistration() {
+		TestTrackMatePlugin testPlugin = new TestTrackMatePlugin();
+		testPlugin.setUp();
+		ObjectService objectService = testPlugin.getLocalContext().service(ObjectService.class);
+		
+		List<TrackMate> trackMateInstances = objectService.getObjects(TrackMate.class);
+		assertTrue(trackMateInstances.size() == 1);
+		assertTrue(trackMateInstances.get(0) instanceof TrackMate);
+	}
+
+	private class TestTrackMatePlugin extends TrackMatePlugIn {
+
+		@SuppressWarnings("unused")
+		public void setUp() {
+			ImagePlus imp = IJ.createImage("Test Image", 256, 256, 10, 8);
+			Settings settings = createSettings(imp);
+			Model model = createModel(imp);
+			TrackMate trackMate = createTrackMate(model, settings);
+		}
+
+		public Context getLocalContext() {
+			return TMUtils.getContext();
+		}
+
+	}
+}


### PR DESCRIPTION
When started via `TrackMatePlugin`, we add the current `TrackMate` instance to `ObjectService`, so that it's retrievable from scripts.

The replicates the changes from https://github.com/trackmate-sc/TrackMate/pull/153 that got lost with https://github.com/trackmate-sc/TrackMate/commit/0846d838972bf4d96f151231f6447d618c7581a6#diff-43d9484af7470283968294400d50d5898b0d73c5827b532ca8dd81c8579e8b7f.

See also this discussion on zulip:
https://imagesc.zulipchat.com/#narrow/stream/327400-TrackMate/topic/Running.20Trackmate.20within.20napari-imagej