### PR TITLE
refactor: moving execTrackFiltering method

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/Model.java
+++ b/src/main/java/fiji/plugin/trackmate/Model.java
@@ -958,4 +958,55 @@ public class Model
 		}
 	}
 
+
+	public boolean execTrackFiltering( final boolean doLogIt, final Settings settings )
+	{
+		// Cannot be canceled.
+
+		if ( doLogIt )
+		{
+			final Logger logger = getLogger();
+			logger.log( "Starting track filtering process.\n" );
+		}
+
+		beginUpdate();
+		try
+		{
+			for ( final Integer trackID : getTrackModel().trackIDs( false ) )
+			{
+				boolean trackIsOk = true;
+				for ( final FeatureFilter filter : settings.getTrackFilters() )
+				{
+					final Double tval = filter.value;
+					final Double val = getFeatureModel().getTrackFeature( trackID, filter.feature );
+					if ( null == val )
+						continue;
+
+					if ( filter.isAbove )
+					{
+						if ( val < tval )
+						{
+							trackIsOk = false;
+							break;
+						}
+					}
+					else
+					{
+						if ( val > tval )
+						{
+							trackIsOk = false;
+							break;
+						}
+					}
+				}
+				setTrackVisibility( trackID, trackIsOk );
+			}
+		}
+		finally
+		{
+			endUpdate();
+		}
+		return true;
+	}
+
 }

--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -689,56 +689,6 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 		return true;
 	}
 
-	public boolean execTrackFiltering( final boolean doLogIt )
-	{
-		// Cannot be canceled.
-
-		if ( doLogIt )
-		{
-			final Logger logger = model.getLogger();
-			logger.log( "Starting track filtering process.\n" );
-		}
-
-		model.beginUpdate();
-		try
-		{
-			for ( final Integer trackID : model.getTrackModel().trackIDs( false ) )
-			{
-				boolean trackIsOk = true;
-				for ( final FeatureFilter filter : settings.getTrackFilters() )
-				{
-					final Double tval = filter.value;
-					final Double val = model.getFeatureModel().getTrackFeature( trackID, filter.feature );
-					if ( null == val )
-						continue;
-
-					if ( filter.isAbove )
-					{
-						if ( val < tval )
-						{
-							trackIsOk = false;
-							break;
-						}
-					}
-					else
-					{
-						if ( val > tval )
-						{
-							trackIsOk = false;
-							break;
-						}
-					}
-				}
-				model.setTrackVisibility( trackID, trackIsOk );
-			}
-		}
-		finally
-		{
-			model.endUpdate();
-		}
-		return true;
-	}
-
 	@Override
 	public String toString()
 	{
@@ -814,7 +764,7 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 		if ( isCanceled() )
 			return true;
 
-		if ( !execTrackFiltering( true ) )
+		if ( !model.execTrackFiltering( true ,settings) )
 			return false;
 
 		return true;

--- a/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/TrackFilterDescriptor.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/wizard/descriptors/TrackFilterDescriptor.java
@@ -66,9 +66,10 @@ public class TrackFilterDescriptor extends WizardPanelDescriptor
 
 	private void filterTracks()
 	{
+		final Model model = trackmate.getModel();
 		final FilterGuiPanel component = ( FilterGuiPanel ) targetPanel;
 		trackmate.getSettings().setTrackFilters( component.getFeatureFilters() );
-		trackmate.execTrackFiltering( false );
+		model.execTrackFiltering(false,trackmate.getSettings());
 	}
 
 	@Override
@@ -126,9 +127,10 @@ public class TrackFilterDescriptor extends WizardPanelDescriptor
 	@Override
 	public void displayingPanel()
 	{
+		final Model model = trackmate.getModel();
 		final FilterGuiPanel component = ( FilterGuiPanel ) targetPanel;
 		trackmate.getSettings().setTrackFilters( component.getFeatureFilters() );
-		trackmate.execTrackFiltering( false );
+		model.execTrackFiltering(false,trackmate.getSettings());
 	}
 
 	@Override
@@ -140,7 +142,7 @@ public class TrackFilterDescriptor extends WizardPanelDescriptor
 		final FilterGuiPanel component = ( FilterGuiPanel ) targetPanel;
 		final List< FeatureFilter > featureFilters = component.getFeatureFilters();
 		trackmate.getSettings().setTrackFilters( featureFilters );
-		trackmate.execTrackFiltering( false );
+		model.execTrackFiltering(false,trackmate.getSettings());
 
 		final int ntotal = model.getTrackModel().nTracks( false );
 		if ( featureFilters == null || featureFilters.isEmpty() )


### PR DESCRIPTION
Document Link : https://docs.google.com/document/d/1TEh2IvcwTXFVyL9KyT-EnExBwEG_jn8t26m_DSXt9FY/edit?usp=sharing

The above document has the refactoring information

Refactor Technique: Move method/field

Package Location: package fiji.plugin.trackmate.graph;

Description: The method execTrackFiltering is more interested in the members of the type Model. Hence I have moved this method from Trackmate.java to Model.java.

I have used this refactoring to eradicate Feature Envy smell that was identified through designiteJava. After the refactoring, the Feature Envy smell was eradicated.
