### PR TITLE
Clean up threading

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/SpotCollection.java
+++ b/src/main/java/fiji/plugin/trackmate/SpotCollection.java
@@ -31,10 +31,10 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import fiji.plugin.trackmate.features.FeatureFilter;
+import fiji.plugin.trackmate.util.Threads;
 import net.imglib2.algorithm.MultiThreaded;
 
 /**
@@ -188,7 +188,7 @@ public class SpotCollection implements MultiThreaded
 		final Double val = visible ? ONE : ZERO;
 		final Collection< Integer > frames = content.keySet();
 
-		final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 		for ( final Integer frame : frames )
 		{
 
@@ -231,7 +231,7 @@ public class SpotCollection implements MultiThreaded
 	{
 
 		final Collection< Integer > frames = content.keySet();
-		final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 
 		for ( final Integer frame : frames )
 		{
@@ -292,7 +292,7 @@ public class SpotCollection implements MultiThreaded
 	{
 
 		final Collection< Integer > frames = content.keySet();
-		final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 
 		for ( final Integer frame : frames )
 		{

--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,6 +46,7 @@ import fiji.plugin.trackmate.features.FeatureFilter;
 import fiji.plugin.trackmate.features.SpotFeatureCalculator;
 import fiji.plugin.trackmate.features.TrackFeatureCalculator;
 import fiji.plugin.trackmate.tracking.SpotTracker;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.gui.Roi;
 import net.imagej.ImgPlus;
@@ -489,7 +489,7 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 				+ ( ( threadsPerFrame > 1 ) ? ( threadsPerFrame + " threads" ) : "1 thread" )
 				+ " per frame.\n" );
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( nSimultaneousFrames );
+		final ExecutorService executorService = Threads.newFixedThreadPool( nSimultaneousFrames );
 		final List< Future< Boolean > > tasks = new ArrayList<>( numFrames );
 		for ( int i = settings.tstart; i <= settings.tend; i++ )
 		{

--- a/src/main/java/fiji/plugin/trackmate/TrackMate.java
+++ b/src/main/java/fiji/plugin/trackmate/TrackMate.java
@@ -578,6 +578,7 @@ public class TrackMate implements Benchmark, MultiThreaded, Algorithm, Named, Ca
 			final Future< Boolean > task = executorService.submit( callable );
 			tasks.add( task );
 		}
+		executorService.shutdown();
 		logger.setStatus( "Detection..." );
 		logger.setProgress( 0 );
 

--- a/src/main/java/fiji/plugin/trackmate/action/autonaming/AutoNamingController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/autonaming/AutoNamingController.java
@@ -32,6 +32,7 @@ import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.gui.Icons;
 import fiji.plugin.trackmate.util.EverythingDisablerAndReenabler;
+import fiji.plugin.trackmate.util.Threads;
 
 public class AutoNamingController
 {
@@ -61,25 +62,21 @@ public class AutoNamingController
 	{
 		final EverythingDisablerAndReenabler disabler = new EverythingDisablerAndReenabler( gui, new Class[] { JLabel.class } );
 		disabler.disable();
-		new Thread( "TrackMateAutoNamingThread" )
+		Threads.run( "TrackMateAutoNamingThread", () ->
 		{
-			@Override
-			public void run()
+			try
 			{
-				try
-				{
-					logger.log( "Applying naming rule: " + autoNaming.toString() + ".\n" );
-					logger.setStatus( "Spot auto-naming" );
-					AutoNamingPerformer.autoNameSpots( trackmate.getModel(), autoNaming );
-					trackmate.getModel().notifyFeaturesComputed();
-					logger.log( "Spot auto-naming done.\n" );
-				}
-				finally
-				{
-					disabler.reenable();
-				}
+				logger.log( "Applying naming rule: " + autoNaming.toString() + ".\n" );
+				logger.setStatus( "Spot auto-naming" );
+				AutoNamingPerformer.autoNameSpots( trackmate.getModel(), autoNaming );
+				trackmate.getModel().notifyFeaturesComputed();
+				logger.log( "Spot auto-naming done.\n" );
 			}
-		}.start();
+			finally
+			{
+				disabler.reenable();
+			}
+		} );
 	}
 
 	public void show()

--- a/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
+++ b/src/main/java/fiji/plugin/trackmate/action/closegaps/CloseGapsController.java
@@ -31,6 +31,7 @@ import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.gui.GuiUtils;
 import fiji.plugin.trackmate.util.EverythingDisablerAndReenabler;
+import fiji.plugin.trackmate.util.Threads;
 
 public class CloseGapsController
 {
@@ -58,24 +59,20 @@ public class CloseGapsController
 	{
 		final EverythingDisablerAndReenabler disabler = new EverythingDisablerAndReenabler( gui, new Class[] { JLabel.class } );
 		disabler.disable();
-		new Thread( "TrackMateGapClosingThread" )
+		Threads.run( "TrackMateGapClosingThread", () ->
 		{
-			@Override
-			public void run()
+			try
 			{
-				try
-				{
-					logger.log( "Applying gap-closing method: " + gapClosingMethod.toString() + ".\n" );
-					logger.setStatus( "Gap-closing" );
-					gapClosingMethod.execute( trackmate, logger );
-					logger.log( "Gap-closing done.\n" );
-				}
-				finally
-				{
-					disabler.reenable();
-				}
+				logger.log( "Applying gap-closing method: " + gapClosingMethod.toString() + ".\n" );
+				logger.setStatus( "Gap-closing" );
+				gapClosingMethod.execute( trackmate, logger );
+				logger.log( "Gap-closing done.\n" );
 			}
-		}.start();
+			finally
+			{
+				disabler.reenable();
+			}
+		} );
 	}
 
 	public void show()

--- a/src/main/java/fiji/plugin/trackmate/action/fit/AbstractSpotFitter.java
+++ b/src/main/java/fiji/plugin/trackmate/action/fit/AbstractSpotFitter.java
@@ -27,13 +27,13 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.apache.commons.math3.fitting.leastsquares.LevenbergMarquardtOptimizer;
 
 import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.ImagePlus;
 import net.imagej.ImgPlus;
@@ -88,7 +88,7 @@ public abstract class AbstractSpotFitter implements SpotFitter
 		logger.log( String.format( "Starting fitting with %d threads.\n", numThreads ) );
 		logger.setStatus( "Spot fitting" );
 		final long start = System.currentTimeMillis();
-		final ExecutorService executorService = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorService = Threads.newFixedThreadPool( numThreads );
 		final List< Future< ? > > futures = new ArrayList<>();
 		for ( final Spot spot : spots )
 			futures.add( executorService.submit( () -> fit( spot ) ) );

--- a/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/DetectionUtils.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import org.scijava.thread.ThreadService;
@@ -40,6 +39,7 @@ import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.TrackMate;
 import fiji.plugin.trackmate.detection.util.MedianFilter2D;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.ImagePlus;
 import net.imagej.ImgPlus;
@@ -111,60 +111,56 @@ public class DetectionUtils
 			final Consumer< Boolean > buttonEnabler )
 	{
 		buttonEnabler.accept( false );
-		new Thread( "TrackMate preview detection thread" )
+		Threads.run("TrackMate preview detection thread", () ->
 		{
-			@Override
-			public void run()
+			try
 			{
-				try
+
+				final Settings lSettings = new Settings( settings.imp );
+				lSettings.tstart = frame;
+				lSettings.tend = frame;
+				settings.setRoi( settings.imp.getRoi() );
+
+				lSettings.detectorFactory = detectorFactory;
+				lSettings.detectorSettings = detectorSettings;
+
+				final TrackMate trackmate = new TrackMate( lSettings );
+				trackmate.getModel().setLogger( logger );
+
+				final boolean detectionOk = trackmate.execDetection();
+				if ( !detectionOk )
 				{
-
-					final Settings lSettings = new Settings( settings.imp );
-					lSettings.tstart = frame;
-					lSettings.tend = frame;
-					settings.setRoi( settings.imp.getRoi() );
-
-					lSettings.detectorFactory = detectorFactory;
-					lSettings.detectorSettings = detectorSettings;
-
-					final TrackMate trackmate = new TrackMate( lSettings );
-					trackmate.getModel().setLogger( logger );
-
-					final boolean detectionOk = trackmate.execDetection();
-					if ( !detectionOk )
-					{
-						logger.error( trackmate.getErrorMessage() );
-						return;
-					}
-					logger.log( "Found " + trackmate.getModel().getSpots().getNSpots( false ) + " spots." );
-
-					// Wrap new spots in a list.
-					final SpotCollection newspots = trackmate.getModel().getSpots();
-					final Iterator< Spot > it = newspots.iterator( frame, false );
-					final ArrayList< Spot > spotsToCopy = new ArrayList<>( newspots.getNSpots( frame, false ) );
-					while ( it.hasNext() )
-						spotsToCopy.add( it.next() );
-
-					// Pass new spot list to model.
-					model.getSpots().put( frame, spotsToCopy );
-					// Make them visible
-					for ( final Spot spot : spotsToCopy )
-						spot.putFeature( SpotCollection.VISIBILITY, SpotCollection.ONE );
-
-					// Generate event for listener to reflect changes.
-					model.setSpots( model.getSpots(), true );
+					logger.error( trackmate.getErrorMessage() );
+					return;
 				}
-				catch ( final Exception e )
-				{
-					logger.error( e.getMessage() );
-					e.printStackTrace();
-				}
-				finally
-				{
-					buttonEnabler.accept( true );
-				}
+				logger.log( "Found " + trackmate.getModel().getSpots().getNSpots( false ) + " spots." );
+
+				// Wrap new spots in a list.
+				final SpotCollection newspots = trackmate.getModel().getSpots();
+				final Iterator< Spot > it = newspots.iterator( frame, false );
+				final ArrayList< Spot > spotsToCopy = new ArrayList<>( newspots.getNSpots( frame, false ) );
+				while ( it.hasNext() )
+					spotsToCopy.add( it.next() );
+
+				// Pass new spot list to model.
+				model.getSpots().put( frame, spotsToCopy );
+				// Make them visible
+				for ( final Spot spot : spotsToCopy )
+					spot.putFeature( SpotCollection.VISIBILITY, SpotCollection.ONE );
+
+				// Generate event for listener to reflect changes.
+				model.setSpots( model.getSpots(), true );
 			}
-		}.start();
+			catch ( final Exception e )
+			{
+				logger.error( e.getMessage() );
+				e.printStackTrace();
+			}
+			finally
+			{
+				buttonEnabler.accept( true );
+			}
+		} );
 	}
 
 	/**
@@ -355,7 +351,7 @@ public class DetectionUtils
 		final ThreadService threadService = TMUtils.getContext().getService( ThreadService.class );
 		final ExecutorService es;
 		if ( threadService == null )
-			es = Executors.newCachedThreadPool();
+			es = Threads.newCachedThreadPool();
 		else
 			es = threadService.getExecutorService();
 		List< Point > peaks;

--- a/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/HessianDetector.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.ToDoubleFunction;
 
 import org.scijava.thread.ThreadService;
 
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import ij.gui.Roi;
 import ij.plugin.frame.RoiManager;
@@ -120,7 +120,7 @@ public class HessianDetector< T extends RealType< T > & NativeType< T > > implem
 		// Handle multithreading.
 		final ThreadService threadService = TMUtils.getContext().getService( ThreadService.class );
 		if ( threadService == null )
-			es = Executors.newCachedThreadPool();
+			es = Threads.newCachedThreadPool();
 		else
 			es = threadService.getExecutorService();
 	}

--- a/src/main/java/fiji/plugin/trackmate/detection/LogDetector.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/LogDetector.java
@@ -24,9 +24,8 @@ package fiji.plugin.trackmate.detection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.util.Threads;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.MultiThreaded;
@@ -159,7 +158,7 @@ public class LogDetector< T extends RealType< T > & NativeType< T > > implements
 		final ImgFactory< ComplexFloatType > imgFactory = Util.getArrayOrCellImgFactory( fftinterval, new ComplexFloatType() );
 		fftconv.setFFTImgFactory( imgFactory );
 
-		final ExecutorService service = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService service = Threads.newFixedThreadPool( numThreads );
 		fftconv.setExecutorService( service );
 
 		fftconv.convolve();

--- a/src/main/java/fiji/plugin/trackmate/detection/MaskUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/MaskUtils.java
@@ -26,10 +26,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotRoi;
+import fiji.plugin.trackmate.util.Threads;
 import ij.ImagePlus;
 import ij.gui.PolygonRoi;
 import ij.measure.Measurements;
@@ -208,8 +207,8 @@ public class MaskUtils
 
 		// Get connected components.
 		final ExecutorService executorService = numThreads > 1
-				? Executors.newFixedThreadPool( numThreads )
-				: Executors.newSingleThreadExecutor();
+				? Threads.newFixedThreadPool( numThreads )
+				: Threads.newSingleThreadExecutor();
 
 		ConnectedComponents.labelAllConnectedComponents(
 				bitMask,

--- a/src/main/java/fiji/plugin/trackmate/detection/semiauto/AbstractSemiAutoTracker.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/semiauto/AbstractSemiAutoTracker.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import fiji.plugin.trackmate.Logger;
@@ -38,6 +37,7 @@ import fiji.plugin.trackmate.SelectionModel;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.detection.LogDetector;
 import fiji.plugin.trackmate.detection.SpotDetector;
+import fiji.plugin.trackmate.util.Threads;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.Algorithm;
@@ -156,7 +156,7 @@ public abstract class AbstractSemiAutoTracker< T extends RealType< T > & NativeT
 
 		ok = true;
 		final int nThreads = Math.min( numThreads, spots.size() );
-		final ExecutorService executors = Executors.newFixedThreadPool( nThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( nThreads );
 		final List< Future< ? > > futures = new ArrayList<>( spots.size() );
 		for ( final Spot spot : spots )
 		{

--- a/src/main/java/fiji/plugin/trackmate/features/SpotFeatureCalculator.java
+++ b/src/main/java/fiji/plugin/trackmate/features/SpotFeatureCalculator.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -41,6 +40,7 @@ import fiji.plugin.trackmate.Settings;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.features.spot.SpotAnalyzer;
 import fiji.plugin.trackmate.features.spot.SpotAnalyzerFactoryBase;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import net.imagej.ImgPlus;
 import net.imglib2.algorithm.MultiThreaded;
@@ -223,7 +223,7 @@ public class SpotFeatureCalculator extends MultiThreadedBenchmarkAlgorithm imple
 			tasks.add( frameTask );
 		}
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( nSimultaneousFrames );
+		final ExecutorService executorService = Threads.newFixedThreadPool( nSimultaneousFrames );
 		List< Future< Void > > futures;
 		try
 		{

--- a/src/main/java/fiji/plugin/trackmate/features/edges/AbstractEdgeAnalyzer.java
+++ b/src/main/java/fiji/plugin/trackmate/features/edges/AbstractEdgeAnalyzer.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.swing.ImageIcon;
@@ -38,6 +37,7 @@ import org.scijava.plugin.Plugin;
 
 import fiji.plugin.trackmate.Dimension;
 import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.util.Threads;
 
 /**
  * Abstract class for edge analyzers that are local and not manual. Offers
@@ -199,7 +199,7 @@ public abstract class AbstractEdgeAnalyzer implements EdgeAnalyzer
 			tasks.add( task );
 		}
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorService = Threads.newFixedThreadPool( numThreads );
 		List< Future< Void > > futures;
 		try
 		{

--- a/src/main/java/fiji/plugin/trackmate/features/spot/AbstractSpotFeatureAnalyzer.java
+++ b/src/main/java/fiji/plugin/trackmate/features/spot/AbstractSpotFeatureAnalyzer.java
@@ -26,10 +26,10 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import fiji.plugin.trackmate.Spot;
+import fiji.plugin.trackmate.util.Threads;
 import net.imglib2.algorithm.Benchmark;
 import net.imglib2.algorithm.MultiThreaded;
 import net.imglib2.type.numeric.RealType;
@@ -77,7 +77,7 @@ public abstract class AbstractSpotFeatureAnalyzer< T extends RealType< T > > imp
 			tasks.add( task );
 		}
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorService = Threads.newFixedThreadPool( numThreads );
 		try
 		{
 			final List< Future< Void > > futures = executorService.invokeAll( tasks );

--- a/src/main/java/fiji/plugin/trackmate/features/track/AbstractTrackAnalyzer.java
+++ b/src/main/java/fiji/plugin/trackmate/features/track/AbstractTrackAnalyzer.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.swing.ImageIcon;
@@ -37,6 +36,7 @@ import org.scijava.plugin.Plugin;
 
 import fiji.plugin.trackmate.Dimension;
 import fiji.plugin.trackmate.Model;
+import fiji.plugin.trackmate.util.Threads;
 
 /**
  * Abstract class for track analyzers that are local and not manual. Offers
@@ -198,7 +198,7 @@ public abstract class AbstractTrackAnalyzer implements TrackAnalyzer
 			tasks.add( task );
 		}
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorService = Threads.newFixedThreadPool( numThreads );
 		List< Future< Void > > futures;
 		try
 		{

--- a/src/main/java/fiji/plugin/trackmate/features/track/TrackMotilityAnalyzer.java
+++ b/src/main/java/fiji/plugin/trackmate/features/track/TrackMotilityAnalyzer.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.swing.ImageIcon;
@@ -45,6 +44,7 @@ import fiji.plugin.trackmate.FeatureModel;
 import fiji.plugin.trackmate.Model;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.features.edges.DirectionalChangeAnalyzer;
+import fiji.plugin.trackmate.util.Threads;
 
 @Plugin( type = TrackAnalyzer.class, priority = Priority.LOW )
 public class TrackMotilityAnalyzer implements TrackAnalyzer
@@ -237,7 +237,7 @@ public class TrackMotilityAnalyzer implements TrackAnalyzer
 			tasks.add( task );
 		}
 
-		final ExecutorService executorService = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorService = Threads.newFixedThreadPool( numThreads );
 		List< Future< Void > > futures;
 		try
 		{

--- a/src/main/java/fiji/plugin/trackmate/gui/components/FilterPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/FilterPanel.java
@@ -40,7 +40,6 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -71,6 +70,7 @@ import org.jfree.chart.renderer.xy.XYBarRenderer;
 
 import fiji.plugin.trackmate.features.FeatureFilter;
 import fiji.plugin.trackmate.gui.GuiUtils;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import fiji.util.NumberParser;
 
@@ -556,7 +556,7 @@ public class FilterPanel extends javax.swing.JPanel
 			if ( ex == null )
 			{
 				// Create new waiting line
-				ex = Executors.newSingleThreadScheduledExecutor();
+				ex = Threads.newSingleThreadScheduledExecutor();
 				future = ex.schedule( command, WAIT_DELAY, TimeUnit.SECONDS );
 			}
 			else

--- a/src/main/java/fiji/plugin/trackmate/gui/components/GrapherPanel.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/components/GrapherPanel.java
@@ -58,6 +58,7 @@ import fiji.plugin.trackmate.gui.Icons;
 import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings;
 import fiji.plugin.trackmate.gui.displaysettings.DisplaySettings.TrackMateObject;
 import fiji.plugin.trackmate.util.EverythingDisablerAndReenabler;
+import fiji.plugin.trackmate.util.Threads;
 
 public class GrapherPanel extends JPanel
 {
@@ -126,7 +127,7 @@ public class GrapherPanel extends JPanel
 				"Mean intensity ch1",
 				spotFeatures,
 				spotFeatureNames,
-				( xKey, yKeys ) -> new Thread( () -> plotSpotFeatures( xKey, yKeys ) ).start() );
+				( xKey, yKeys ) -> Threads.run( () -> plotSpotFeatures( xKey, yKeys ) ) );
 		panelSpot.add( spotFeatureSelectionPanel );
 
 		// regen edge features
@@ -138,7 +139,7 @@ public class GrapherPanel extends JPanel
 				"Speed",
 				edgeFeatures,
 				edgeFeatureNames,
-				( xKey, yKeys ) -> new Thread( () -> plotEdgeFeatures( xKey, yKeys ) ).start() );
+				( xKey, yKeys ) -> Threads.run( () -> plotEdgeFeatures( xKey, yKeys ) ) );
 		panelEdges.add( edgeFeatureSelectionPanel );
 
 		// regen trak features
@@ -150,7 +151,7 @@ public class GrapherPanel extends JPanel
 				"Number of spots in track",
 				trackFeatures,
 				trackFeatureNames,
-				( xKey, yKeys ) -> new Thread( () -> plotTrackFeatures( xKey, yKeys ) ).start() );
+				( xKey, yKeys ) -> Threads.run( () -> plotTrackFeatures( xKey, yKeys ) ) );
 		panelTracks.add( trackFeatureSelectionPanel );
 
 		panelSelection = new JPanel();

--- a/src/main/java/fiji/plugin/trackmate/gui/wizard/TrackMateWizardSequence.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/wizard/TrackMateWizardSequence.java
@@ -70,6 +70,7 @@ import fiji.plugin.trackmate.providers.DetectorProvider;
 import fiji.plugin.trackmate.providers.TrackerProvider;
 import fiji.plugin.trackmate.tracking.SpotTrackerFactory;
 import fiji.plugin.trackmate.tracking.manual.ManualTrackerFactory;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.visualization.trackscheme.SpotImageUpdater;
 import fiji.plugin.trackmate.visualization.trackscheme.TrackScheme;
 
@@ -447,17 +448,13 @@ public class TrackMateWizardSequence implements WizardSequence
 		@Override
 		public void actionPerformed( final ActionEvent e )
 		{
-			new Thread( "Launching TrackScheme thread" )
+			Threads.run( "Launching TrackScheme thread", () ->
 			{
-				@Override
-				public void run()
-				{
-					final TrackScheme trackscheme = new TrackScheme( trackmate.getModel(), selectionModel, displaySettings );
-					final SpotImageUpdater thumbnailUpdater = new SpotImageUpdater( trackmate.getSettings() );
-					trackscheme.setSpotImageUpdater( thumbnailUpdater );
-					trackscheme.render();
-				}
-			}.start();
+				final TrackScheme trackscheme = new TrackScheme( trackmate.getModel(), selectionModel, displaySettings );
+				final SpotImageUpdater thumbnailUpdater = new SpotImageUpdater( trackmate.getSettings() );
+				trackscheme.setSpotImageUpdater( thumbnailUpdater );
+				trackscheme.render();
+			} );
 		}
 	}
 
@@ -497,19 +494,15 @@ public class TrackMateWizardSequence implements WizardSequence
 
 	private void showTables( final boolean showSpotTable )
 	{
-		new Thread( "TrackMate table thread." )
+		Threads.run( "TrackMate table thread.", () ->
 		{
-			@Override
-			public void run()
-			{
-				AbstractTMAction action;
-				if ( showSpotTable )
-					action = new ExportAllSpotsStatsAction();
-				else
-					action = new ExportStatsTablesAction();
+			AbstractTMAction action;
+			if ( showSpotTable )
+				action = new ExportAllSpotsStatsAction();
+			else
+				action = new ExportStatsTablesAction();
 
-				action.execute( trackmate, selectionModel, displaySettings, null );
-			}
-		}.start();
+			action.execute( trackmate, selectionModel, displaySettings, null );
+		} );
 	}
 }

--- a/src/main/java/fiji/plugin/trackmate/gui/wizard/WizardController.java
+++ b/src/main/java/fiji/plugin/trackmate/gui/wizard/WizardController.java
@@ -42,6 +42,7 @@ import org.scijava.Cancelable;
 
 import fiji.plugin.trackmate.gui.wizard.TransitionAnimator.Direction;
 import fiji.plugin.trackmate.util.EverythingDisablerAndReenabler;
+import fiji.plugin.trackmate.util.Threads;
 
 public class WizardController
 {
@@ -175,34 +176,30 @@ public class WizardController
 			return;
 
 		final EverythingDisablerAndReenabler reenabler = new EverythingDisablerAndReenabler( wizardPanel.panelButtons, new Class[] { JLabel.class } );
-		new Thread( "Wizard exec thread" )
+		Threads.run( "Wizard exec thread", () ->
 		{
-			@Override
-			public void run()
+			try
 			{
-				try
-				{
-					reenabler.disable();
-					// Wait for the animation to finish.
-					Thread.sleep( 200 );
-					wizardPanel.btnNext.setVisible( false );
-					wizardPanel.btnCancel.setVisible( true );
-					wizardPanel.btnCancel.setEnabled( true );
-					runnable.run();
-				}
-				catch ( final InterruptedException e )
-				{
-					e.printStackTrace();
-				}
-				finally
-				{
-					wizardPanel.btnCancel.setVisible( false );
-					wizardPanel.btnNext.setVisible( true );
-					wizardPanel.btnNext.requestFocusInWindow();
-					reenabler.reenable();
-				}
-			};
-		}.start();
+				reenabler.disable();
+				// Wait for the animation to finish.
+				Thread.sleep( 200 );
+				wizardPanel.btnNext.setVisible( false );
+				wizardPanel.btnCancel.setVisible( true );
+				wizardPanel.btnCancel.setEnabled( true );
+				runnable.run();
+			}
+			catch ( final InterruptedException e )
+			{
+				e.printStackTrace();
+			}
+			finally
+			{
+				wizardPanel.btnCancel.setVisible( false );
+				wizardPanel.btnNext.setVisible( true );
+				wizardPanel.btnNext.requestFocusInWindow();
+				reenabler.reenable();
+			}
+		} );
 	}
 
 	public void init()
@@ -228,7 +225,7 @@ public class WizardController
 		wizardPanel.btnResume.setVisible( true );
 
 		display( saveDescriptor, sequence.current(), Direction.BOTTOM );
-		new Thread( () -> {
+		Threads.run( () -> {
 			try
 			{
 				Thread.sleep( 250 );
@@ -239,7 +236,7 @@ public class WizardController
 			}
 			saveDescriptor.aboutToDisplayPanel();
 			saveDescriptor.displayingPanel();
-		} ).start();
+		} );
 	}
 
 	protected void resume()

--- a/src/main/java/fiji/plugin/trackmate/tracking/jaqaman/SparseLAPFrameToFrameTracker.java
+++ b/src/main/java/fiji/plugin/trackmate/tracking/jaqaman/SparseLAPFrameToFrameTracker.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,6 +51,7 @@ import fiji.plugin.trackmate.tracking.jaqaman.costfunction.CostFunction;
 import fiji.plugin.trackmate.tracking.jaqaman.costfunction.FeaturePenaltyCostFunction;
 import fiji.plugin.trackmate.tracking.jaqaman.costfunction.SquareDistCostFunction;
 import fiji.plugin.trackmate.tracking.jaqaman.costmatrix.JaqamanLinkingCostMatrixCreator;
+import fiji.plugin.trackmate.util.Threads;
 import net.imglib2.algorithm.MultiThreadedBenchmarkAlgorithm;
 
 public class SparseLAPFrameToFrameTracker extends MultiThreadedBenchmarkAlgorithm implements SpotTracker, Cancelable
@@ -175,7 +175,7 @@ public class SparseLAPFrameToFrameTracker extends MultiThreadedBenchmarkAlgorith
 		// Prepare workers.
 		final AtomicInteger progress = new AtomicInteger( 0 );
 		final AtomicBoolean ok = new AtomicBoolean( true );
-		final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 		final List< Future< Void > > futures = new ArrayList<>( framePairs.size() );
 		for ( final int[] framePair : framePairs )
 		{

--- a/src/main/java/fiji/plugin/trackmate/tracking/jaqaman/costmatrix/JaqamanSegmentCostMatrixCreator.java
+++ b/src/main/java/fiji/plugin/trackmate/tracking/jaqaman/costmatrix/JaqamanSegmentCostMatrixCreator.java
@@ -36,17 +36,18 @@ import static fiji.plugin.trackmate.tracking.TrackerKeys.KEY_SPLITTING_MAX_DISTA
 import static fiji.plugin.trackmate.tracking.jaqaman.LAPUtils.checkFeatureMap;
 import static fiji.plugin.trackmate.util.TMUtils.checkMapKeys;
 import static fiji.plugin.trackmate.util.TMUtils.checkParameter;
+
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.tracking.jaqaman.costfunction.CostFunction;
 import fiji.plugin.trackmate.tracking.jaqaman.costfunction.FeaturePenaltyCostFunction;
 import fiji.plugin.trackmate.tracking.jaqaman.costfunction.SquareDistCostFunction;
+import fiji.plugin.trackmate.util.Threads;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import net.imglib2.algorithm.MultiThreaded;
@@ -216,7 +217,7 @@ public class JaqamanSegmentCostMatrixCreator implements CostMatrixCreator< Spot,
 		 * (gap-closing) then the segment middles (merging).
 		 */
 
-		final ExecutorService executorGCM = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executorGCM = Threads.newFixedThreadPool( numThreads );
 		for ( final Spot source : segmentEnds )
 		{
 			executorGCM.submit( new Runnable()
@@ -309,7 +310,7 @@ public class JaqamanSegmentCostMatrixCreator implements CostMatrixCreator< Spot,
 		 */
 		if ( allowSplitting )
 		{
-			final ExecutorService executorS = Executors.newFixedThreadPool( numThreads );
+			final ExecutorService executorS = Threads.newFixedThreadPool( numThreads );
 			for ( final Spot source : allMiddles )
 			{
 				executorS.submit( new Runnable()

--- a/src/main/java/fiji/plugin/trackmate/tracking/kdtree/NearestNeighborTracker.java
+++ b/src/main/java/fiji/plugin/trackmate/tracking/kdtree/NearestNeighborTracker.java
@@ -33,7 +33,6 @@ import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,6 +44,7 @@ import fiji.plugin.trackmate.Logger;
 import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.tracking.SpotTracker;
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.util.TMUtils;
 import net.imglib2.KDTree;
 import net.imglib2.RealPoint;
@@ -110,7 +110,7 @@ public class NearestNeighborTracker extends MultiThreadedBenchmarkAlgorithm impl
 
 		// Prepare executors.
 		final AtomicInteger progress = new AtomicInteger( 0 );
-		final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+		final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 		final List< Future< Void > > futures = new ArrayList<>( frames.size() );
 		for ( int i = frames.first(); i < frames.last(); i++ )
 		{

--- a/src/main/java/fiji/plugin/trackmate/tracking/overlap/OverlapTracker.java
+++ b/src/main/java/fiji/plugin/trackmate/tracking/overlap/OverlapTracker.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -46,6 +45,7 @@ import fiji.plugin.trackmate.Spot;
 import fiji.plugin.trackmate.SpotCollection;
 import fiji.plugin.trackmate.SpotRoi;
 import fiji.plugin.trackmate.tracking.SpotTracker;
+import fiji.plugin.trackmate.util.Threads;
 import math.geom2d.AffineTransform2D;
 import math.geom2d.Point2D;
 import math.geom2d.conic.Circle2D;
@@ -206,7 +206,7 @@ public class OverlapTracker extends MultiThreadedBenchmarkAlgorithm implements S
 			if ( sourceGeometries.isEmpty() || targetGeometries.isEmpty() )
 				continue;
 
-			final ExecutorService executors = Executors.newFixedThreadPool( numThreads );
+			final ExecutorService executors = Threads.newFixedThreadPool( numThreads );
 			final List< Future< IoULink > > futures = new ArrayList<>();
 
 			// Submit work.

--- a/src/main/java/fiji/plugin/trackmate/util/DetectionPreview.java
+++ b/src/main/java/fiji/plugin/trackmate/util/DetectionPreview.java
@@ -87,41 +87,37 @@ public class DetectionPreview
 			final String thresholdKey )
 	{
 		panel.btnPreview.setEnabled( false );
-		new Thread( "TrackMate preview detection thread" )
+		Threads.run( "TrackMate preview detection thread", () ->
 		{
-			@Override
-			public void run()
+			try
 			{
-				try
-				{
-					// Run preview.
-					final Pair< Model, Double > out = runPreviewDetection(
-							settings,
-							frame,
-							detectorFactory,
-							detectorSettings,
-							thresholdKey );
-					if ( out == null )
-						return;
+				// Run preview.
+				final Pair< Model, Double > out = runPreviewDetection(
+						settings,
+						frame,
+						detectorFactory,
+						detectorSettings,
+						thresholdKey );
+				if ( out == null )
+					return;
 
-					final Model sourceModel = out.getA();
-					final Double threshold = out.getB();
-					panel.logger.log( "Found " + sourceModel.getSpots().getNSpots( true ) + " spots." );
+				final Model sourceModel = out.getA();
+				final Double threshold = out.getB();
+				panel.logger.log( "Found " + sourceModel.getSpots().getNSpots( true ) + " spots." );
 
-					// Update target model.
-					updateModelAndHistogram( model, sourceModel, frame, threshold );
-				}
-				catch ( final Exception e )
-				{
-					panel.logger.error( e.getMessage() );
-					e.printStackTrace();
-				}
-				finally
-				{
-					panel.btnPreview.setEnabled( true );
-				}
+				// Update target model.
+				updateModelAndHistogram( model, sourceModel, frame, threshold );
 			}
-		}.start();
+			catch ( final Exception e )
+			{
+				panel.logger.error( e.getMessage() );
+				e.printStackTrace();
+			}
+			finally
+			{
+				panel.btnPreview.setEnabled( true );
+			}
+		} );
 	}
 
 	/**

--- a/src/main/java/fiji/plugin/trackmate/util/OnRequestUpdater.java
+++ b/src/main/java/fiji/plugin/trackmate/util/OnRequestUpdater.java
@@ -87,6 +87,7 @@ public class OnRequestUpdater extends Thread
 		super( "OnRequestUpdater for " + refreshable.toString() );
 		this.refreshable = refreshable;
 		setPriority( Thread.NORM_PRIORITY );
+		setDaemon( true );
 		start();
 	}
 

--- a/src/main/java/fiji/plugin/trackmate/util/PainterThread.java
+++ b/src/main/java/fiji/plugin/trackmate/util/PainterThread.java
@@ -56,6 +56,7 @@ public class PainterThread extends Thread
 	public PainterThread( final ThreadGroup group, final String name, final Paintable paintable )
 	{
 		super( group, name );
+		setDaemon( true );
 		this.paintable = paintable;
 		this.pleaseRepaint = false;
 	}

--- a/src/main/java/fiji/plugin/trackmate/util/QualityHistogramChart.java
+++ b/src/main/java/fiji/plugin/trackmate/util/QualityHistogramChart.java
@@ -33,7 +33,6 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -396,7 +395,7 @@ public class QualityHistogramChart extends JPanel
 			if ( ex == null )
 			{
 				// Create new waiting line
-				ex = Executors.newSingleThreadScheduledExecutor();
+				ex = Threads.newSingleThreadScheduledExecutor();
 				future = ex.schedule( command, WAIT_DELAY, TimeUnit.SECONDS );
 			}
 			else

--- a/src/main/java/fiji/plugin/trackmate/util/Threads.java
+++ b/src/main/java/fiji/plugin/trackmate/util/Threads.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * TrackMate: your buddy for everyday tracking.
+ * %%
+ * Copyright (C) 2010 - 2023 TrackMate developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package fiji.plugin.trackmate.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+public final class Threads {
+
+	public static void run( final Runnable r )
+	{
+		new Thread( r ).start();
+	}
+
+	public static void run( final String name, final Runnable r )
+	{
+		new Thread( r, name ).start();
+	}
+
+	public static ExecutorService newFixedThreadPool( final int nThreads )
+	{
+		return Executors.newFixedThreadPool( nThreads );
+	}
+	public static ExecutorService newCachedThreadPool()
+	{
+		return Executors.newCachedThreadPool();
+	}
+
+	public static ExecutorService newSingleThreadExecutor()
+	{
+		return Executors.newSingleThreadExecutor();
+	}
+
+	public static ScheduledExecutorService newSingleThreadScheduledExecutor()
+	{
+		return Executors.newSingleThreadScheduledExecutor();
+	}
+}

--- a/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackSchemeToolbar.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/trackscheme/TrackSchemeToolbar.java
@@ -48,6 +48,7 @@ import javax.swing.JComboBox;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
 
+import fiji.plugin.trackmate.util.Threads;
 import fiji.plugin.trackmate.visualization.trackscheme.utils.SearchBar;
 
 public class TrackSchemeToolbar extends JToolBar
@@ -102,21 +103,17 @@ public class TrackSchemeToolbar extends JToolBar
 			@Override
 			public void actionPerformed( final ActionEvent e )
 			{
-				new Thread( "TrackScheme creating thumbnails thread" )
+				Threads.run( "TrackScheme creating thumbnails thread", () ->
 				{
-					@Override
-					public void run()
-					{
-						final boolean isEnabled = trackScheme.toggleThumbnail();
-						ImageIcon thumbnailIcon;
-						if ( !isEnabled )
-							thumbnailIcon = THUMBNAIL_OFF_ICON;
-						else
-							thumbnailIcon = THUMBNAIL_ON_ICON;
+					final boolean isEnabled = trackScheme.toggleThumbnail();
+					ImageIcon thumbnailIcon;
+					if ( !isEnabled )
+						thumbnailIcon = THUMBNAIL_OFF_ICON;
+					else
+						thumbnailIcon = THUMBNAIL_ON_ICON;
 
-						putValue( SMALL_ICON, thumbnailIcon );
-					}
-				}.start();
+					putValue( SMALL_ICON, thumbnailIcon );
+				} );
 			}
 		};
 		final JButton toggleThumbnailsButton = new JButton( toggleThumbnailAction );
@@ -235,15 +232,11 @@ public class TrackSchemeToolbar extends JToolBar
 				@Override
 				public void actionPerformed( final ActionEvent arg0 )
 				{
-					new Thread( "TrackScheme re-applying style thread" )
+					Threads.run( "TrackScheme re-applying style thread", () ->
 					{
-						@Override
-						public void run()
-						{
-							trackScheme.doTrackStyle();
-							trackScheme.refresh();
-						}
-					}.start();
+						trackScheme.doTrackStyle();
+						trackScheme.refresh();
+					} );
 				}
 			} );
 		}
@@ -262,16 +255,12 @@ public class TrackSchemeToolbar extends JToolBar
 				public void actionPerformed( final ActionEvent e )
 				{
 					final String selectedStyle = ( String ) selectStyleBox.getSelectedItem();
-					new Thread( "TrackScheme changing style thread" )
+					Threads.run( "TrackScheme changing style thread", () ->
 					{
-						@Override
-						public void run()
-						{
-							trackScheme.stylist.setStyle( selectedStyle );
-							trackScheme.doTrackStyle();
-							trackScheme.refresh();
-						}
-					}.start();
+						trackScheme.stylist.setStyle( selectedStyle );
+						trackScheme.doTrackStyle();
+						trackScheme.refresh();
+					} );
 				}
 			} );
 


### PR DESCRIPTION
This patchset updates the thread usage to go through a common utility class, and also fixes a couple of places where `ExecutorService`s and `Thread`s were not being managed in a way allowing JVM shutdown.
