### PR TITLE
export table filename

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/Settings.java
+++ b/src/main/java/fiji/plugin/trackmate/Settings.java
@@ -302,6 +302,15 @@ public class Settings
 	/*
 	 * METHODS
 	 */
+        
+        /**
+         * Returns a string of the name of the image without the extension, with the full path
+         * @return full name of the image without the extension
+         */
+        public String getFileNameWithoutExtension()
+        {
+            return imageFolder+imageFileName.substring(0, imageFileName.lastIndexOf("."));
+        }
 
 	/**
 	 * Returns a string description of the target image.

--- a/src/main/java/fiji/plugin/trackmate/action/ExportAllSpotsStatsAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportAllSpotsStatsAction.java
@@ -51,12 +51,12 @@ public class ExportAllSpotsStatsAction extends AbstractTMAction
 	@Override
 	public void execute( final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings, final Frame parent )
 	{
-		createSpotsTable( trackmate.getModel(), selectionModel, displaySettings ).render();
+            	createSpotsTable( trackmate.getModel(), selectionModel, displaySettings, trackmate.getSettings().getFileNameWithoutExtension() ).render();
 	}
 
-	public static final AllSpotsTableView createSpotsTable( final Model model, final SelectionModel selectionModel, final DisplaySettings displaySettings )
+	public static final AllSpotsTableView createSpotsTable( final Model model, final SelectionModel selectionModel, final DisplaySettings displaySettings, final String imageFileName )
 	{
-		return new AllSpotsTableView( model, selectionModel, displaySettings );
+		return new AllSpotsTableView( model, selectionModel, displaySettings, imageFileName );
 	}
 
 	// Invisible because called on the view config panel.

--- a/src/main/java/fiji/plugin/trackmate/action/ExportStatsTablesAction.java
+++ b/src/main/java/fiji/plugin/trackmate/action/ExportStatsTablesAction.java
@@ -57,12 +57,12 @@ public class ExportStatsTablesAction extends AbstractTMAction
 	@Override
 	public void execute( final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings, final Frame parent )
 	{
-		createTrackTables( trackmate.getModel(), selectionModel, displaySettings ).render();
+		createTrackTables( trackmate.getModel(), selectionModel, displaySettings, trackmate.getSettings().getFileNameWithoutExtension()  ).render();
 	}
 
-	public static TrackTableView createTrackTables( final Model model, final SelectionModel selectionModel, final DisplaySettings displaySettings )
+	public static TrackTableView createTrackTables( final Model model, final SelectionModel selectionModel, final DisplaySettings displaySettings, final String imageFileName )
 	{
-		return new TrackTableView( model, selectionModel, displaySettings );
+		return new TrackTableView( model, selectionModel, displaySettings, imageFileName );
 	}
 
 	// Invisible because called on the view config panel.

--- a/src/main/java/fiji/plugin/trackmate/action/TrackBranchAnalysis.java
+++ b/src/main/java/fiji/plugin/trackmate/action/TrackBranchAnalysis.java
@@ -55,12 +55,12 @@ public class TrackBranchAnalysis extends AbstractTMAction
 	@Override
 	public void execute( final TrackMate trackmate, final SelectionModel selectionModel, final DisplaySettings displaySettings, final Frame parent )
 	{
-		createBranchTable( trackmate.getModel(), selectionModel ).render();
+		createBranchTable( trackmate.getModel(), selectionModel, trackmate.getSettings().getFileNameWithoutExtension()  ).render();
 	}
 
-	public static final BranchTableView createBranchTable( final Model model, final SelectionModel selectionModel )
+	public static final BranchTableView createBranchTable( final Model model, final SelectionModel selectionModel, final String imageFileName )
 	{
-		return new BranchTableView( model, selectionModel );
+		return new BranchTableView( model, selectionModel, imageFileName );
 	}
 	
 	@Plugin( type = TrackMateActionFactory.class, enabled = true )

--- a/src/main/java/fiji/plugin/trackmate/visualization/table/AllSpotsTableView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/table/AllSpotsTableView.java
@@ -78,7 +78,7 @@ public class AllSpotsTableView extends JFrame implements TrackMateModelView, Mod
 
 	private static final String KEY = "SPOT_TABLE";
 
-	public static String selectedFile = TrackTableView.selectedFile;
+	private String selectedFile =  System.getProperty( "user.home" ) + File.separator + "spots.csv";
 
 	private final Model model;
 
@@ -88,13 +88,13 @@ public class AllSpotsTableView extends JFrame implements TrackMateModelView, Mod
 
 	private final SelectionModel selectionModel;
 
-	public AllSpotsTableView( final Model model, final SelectionModel selectionModel, final DisplaySettings ds )
+	public AllSpotsTableView( final Model model, final SelectionModel selectionModel, final DisplaySettings ds, final String imageFileName )
 	{
 		super( "All spots table" );
 		setIconImage( TRACKMATE_ICON.getImage() );
 		this.model = model;
 		this.selectionModel = selectionModel;
-
+                this.selectedFile = imageFileName+"_spots.csv";
 		/*
 		 * GUI.
 		 */
@@ -154,6 +154,7 @@ public class AllSpotsTableView extends JFrame implements TrackMateModelView, Mod
 
 	public void exportToCsv()
 	{
+            
 		final File file = FileChooser.chooseFile(
 				this,
 				selectedFile,

--- a/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/table/BranchTableView.java
@@ -77,17 +77,19 @@ public class BranchTableView extends JFrame implements TrackMateModelView
 
 	private static final String KEY = "SPOT_TABLE";
 
-	public static String selectedFile = TrackTableView.selectedFile;
+	private String selectedFile = System.getProperty( "user.home" ) + File.separator + "branchs.csv";
 
 	private final Model model;
 
 	private final TablePanel< Branch > branchTable;
 
-	public BranchTableView( final Model model, final SelectionModel selectionModel )
+	public BranchTableView( final Model model, final SelectionModel selectionModel, final String imageFileName )
 	{
 		super( "Branch table" );
 		setIconImage( TRACKMATE_ICON.getImage() );
 		this.model = model;
+                this.selectedFile = imageFileName+"_branchs.csv";
+		
 
 		/*
 		 * GUI.

--- a/src/main/java/fiji/plugin/trackmate/visualization/table/TrackTableView.java
+++ b/src/main/java/fiji/plugin/trackmate/visualization/table/TrackTableView.java
@@ -83,7 +83,7 @@ public class TrackTableView extends JFrame implements TrackMateModelView, ModelC
 
 	private static final String KEY = "TRACK_TABLES";
 
-	public static String selectedFile = System.getProperty( "user.home" ) + File.separator + "export.csv";
+	private String selectedFile = System.getProperty( "user.home" ) + File.separator + "tracks.csv";
 
 	private final Model model;
 
@@ -97,12 +97,14 @@ public class TrackTableView extends JFrame implements TrackMateModelView, ModelC
 
 	private final SelectionModel selectionModel;
 
-	public TrackTableView( final Model model, final SelectionModel selectionModel, final DisplaySettings ds )
+	public TrackTableView( final Model model, final SelectionModel selectionModel, final DisplaySettings ds, final String imageFileName )
 	{
 		super( "Track tables" );
 		setIconImage( TRACKMATE_ICON.getImage() );
 		this.model = model;
 		this.selectionModel = selectionModel;
+                this.selectedFile = imageFileName+"_tracks.csv";
+		
 
 		/*
 		 * GUI.

--- a/src/test/java/fiji/plugin/trackmate/visualization/table/TrackMateTableExample.java
+++ b/src/test/java/fiji/plugin/trackmate/visualization/table/TrackMateTableExample.java
@@ -45,7 +45,8 @@ public class TrackMateTableExample
 		final SelectionModel selectionModel = new SelectionModel( model );
 		final DisplaySettings ds = reader.getDisplaySettings();
 		model.getSpots().iterable( 1, true ).forEach( selectionModel::addSpotToSelection );
+                final String exportFile = System.getProperty( "user.home" ) + File.separator + "test";
 
-		new TrackTableView( model, selectionModel, ds ).render();
+		new TrackTableView( model, selectionModel, ds, exportFile ).render();
 	}
 }


### PR DESCRIPTION
Change the proposed filename when clicking on "export to csv" from the spot/track/branch table views
The proposed filename is now path_to_image_folder/image_name_"_spots.csv"