### PR TITLE
Fix error wrt changed API in imglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>38.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,14 @@
 
 		<fontchooser.version>2.5.2</fontchooser.version>
 		<javaGeom.version>0.11.1</javaGeom.version>
-		<imglib2.version>6.1.0</imglib2.version>
+
+		<imglib2.version>7.1.0</imglib2.version>
+		<imglib2-realtransform.version>4.0.3</imglib2-realtransform.version>
+		<imglib2-roi.version>0.15.0</imglib2-roi.version>
+		<imglib2-cache.version>1.0.0-beta-18</imglib2-cache.version>
+		<imglib2-algorithm.version>0.15.3</imglib2-algorithm.version>
+		<imglib2-ij.version>2.0.2</imglib2-ij.version>
+		<bigdataviewer-core.version>10.6.0</bigdataviewer-core.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/fiji/plugin/trackmate/detection/MaskUtils.java
+++ b/src/main/java/fiji/plugin/trackmate/detection/MaskUtils.java
@@ -33,6 +33,7 @@ import ij.ImagePlus;
 import ij.gui.PolygonRoi;
 import ij.measure.Measurements;
 import ij.process.FloatPolygon;
+import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessible;
@@ -280,7 +281,7 @@ public class MaskUtils
 		while ( iterator.hasNext() )
 		{
 			final LabelRegion< Integer > region = iterator.next();
-			final LabelRegionCursor cursor = region.localizingCursor();
+			final Cursor< Void > cursor = region.inside().localizingCursor();
 			final int[] cursorPos = new int[ labeling.numDimensions() ];
 			final long[] sum = new long[ 3 ];
 			while ( cursor.hasNext() )
@@ -358,7 +359,7 @@ public class MaskUtils
 		while ( iterator.hasNext() )
 		{
 			final LabelRegion< Integer > region = iterator.next();
-			final LabelRegionCursor cursor = region.localizingCursor();
+			final Cursor< Void > cursor = region.inside().localizingCursor();
 			final int[] cursorPos = new int[ labeling.numDimensions() ];
 			final long[] sum = new long[ 3 ];
 			double quality = Double.NEGATIVE_INFINITY;

--- a/src/main/java/fiji/plugin/trackmate/tracking/kdtree/NearestNeighborFlagSearchOnKDTree.java
+++ b/src/main/java/fiji/plugin/trackmate/tracking/kdtree/NearestNeighborFlagSearchOnKDTree.java
@@ -28,6 +28,8 @@ import net.imglib2.RealLocalizable;
 import net.imglib2.Sampler;
 import net.imglib2.neighborsearch.NearestNeighborSearch;
 
+
+// TODO: revise for new KDTree implementation, where KDTreeNode are reusable proxies.
 public class NearestNeighborFlagSearchOnKDTree< T > implements NearestNeighborSearch< FlagNode< T > >
 {
 
@@ -78,8 +80,8 @@ public class NearestNeighborFlagSearchOnKDTree< T > implements NearestNeighborSe
 		final boolean leftIsNearBranch = axisDiff < 0;
 
 		// search the near branch
-		final KDTreeNode< FlagNode< T > > nearChild = leftIsNearBranch ? current.left : current.right;
-		final KDTreeNode< FlagNode< T > > awayChild = leftIsNearBranch ? current.right : current.left;
+		final KDTreeNode< FlagNode< T > > nearChild = leftIsNearBranch ? current.left() : current.right();
+		final KDTreeNode< FlagNode< T > > awayChild = leftIsNearBranch ? current.right() : current.left();
 		if ( nearChild != null )
 			searchNode( nearChild );
 


### PR DESCRIPTION
In particular:
* KDTree implementation was slightly changed: https://github.com/imglib/imglib2/pull/333
* IterableRegion no longer is IterableInterval but has nested `inside()` IterableInterval: https://github.com/imglib/imglib2-roi/pull/71

I would suggest to revisit and merge this when the new ImgLib2 `getType()` API  https://github.com/imglib/imglib2/pull/312 is merged and released