### PR TITLE
Log: Reduce severity for default tracking parameters message

### DIFF
--- a/src/main/java/fiji/plugin/trackmate/io/SettingsPersistence.java
+++ b/src/main/java/fiji/plugin/trackmate/io/SettingsPersistence.java
@@ -43,8 +43,8 @@ public class SettingsPersistence
 		final TmXmlReader reader = new TmXmlReader( lastSettingsFile );
 		if ( !reader.isReadingOk() )
 		{
-			logger.error( "Could not read the last used settings file at " + lastSettingsFile + ".\n" );
-			logger.error( "Using built-in defaults.\n" );
+			logger.log( "No last-used settings found in '" + lastSettingsFile + "'.\n" );
+			logger.log( "Using built-in defaults.\n" );
 			return getDefaultSettings( imp );
 		}
 


### PR DESCRIPTION
Previously, using logger.error() for default tracking parameters unnecessarily alarmed users. This change downgrades the log level to a more appropriate level  to avoid false alarms.

Fix #339